### PR TITLE
fix: correct decimal formatting in templates and Go code

### DIFF
--- a/internal/models/symbol.go
+++ b/internal/models/symbol.go
@@ -284,9 +284,9 @@ func (o *Option) GetFormattedTotalProfit() string {
 func (o *Option) GetFormattedPercentOfProfit() string {
 	percent := o.CalculatePercentOfProfit()
 	if percent < 0 {
-		return fmt.Sprintf("<span class=\"negative\">%.0f%%</span>", percent)
+		return fmt.Sprintf("<span class=\"negative\">%.2f%%</span>", percent)
 	}
-	return fmt.Sprintf("%.0f%%", percent)
+	return fmt.Sprintf("%.2f%%", percent)
 }
 
 type Dividend struct {

--- a/internal/polygon/live_integration_test.go
+++ b/internal/polygon/live_integration_test.go
@@ -263,7 +263,7 @@ func TestLivePolygonIntegration(t *testing.T) {
 			t.Errorf("Expected positive current price, got %f", info.CurrentPrice)
 		}
 
-		t.Logf("✅ NVDA details: %s, Current Price: $%.2f, Market Cap: $%.0f", info.Name, info.CurrentPrice, info.MarketCap)
+		t.Logf("✅ NVDA details: %s, Current Price: $%.2f, Market Cap: $%.2f", info.Name, info.CurrentPrice, info.MarketCap)
 	})
 
 	t.Run("TestServiceFetchDividendHistory", func(t *testing.T) {

--- a/internal/web/templates/options.html
+++ b/internal/web/templates/options.html
@@ -259,10 +259,10 @@
                                                         {{if eq .Type "Put"}}P{{else}}C{{end}}
                                                     </span>
                                                 </td>
-                                                <td class="neutral-currency">${{printf "%.0f" .Strike}}</td>
+                                                <td class="neutral-currency">${{printf "%.2f" .Strike}}</td>
                                                 <td>{{.Contracts}}</td>
                                                 <td class="neutral-currency">{{formatCurrency (mul (mul .Strike .Contracts) 100)}}</td>
-                                                <td class="premium-column {{if lt .CalculateTotalProfit 0.0}}negative{{else if gt .CalculateTotalProfit 0.0}}positive{{else}}neutral-currency{{end}}">${{printf "%.0f" .CalculateTotalProfit}}</td>
+                                                <td class="premium-column {{if lt .CalculateTotalProfit 0.0}}negative{{else if gt .CalculateTotalProfit 0.0}}positive{{else}}neutral-currency{{end}}">${{printf "%.2f" .CalculateTotalProfit}}</td>
                                                 <td>{{.EntryDate.Format "01/02/2006"}}</td>
                                             </tr>
                                             {{end}}

--- a/internal/web/templates/symbol.html
+++ b/internal/web/templates/symbol.html
@@ -152,7 +152,7 @@
                                     </td>
                                     <td>{{.Opened.Format "1/2/2006"}}</td>
                                     <td>{{if .Closed}}{{.Closed.Format "1/2/2006"}}{{else}}-{{end}}</td>
-                                    <td>{{printf "%.0f" .Strike}}</td>
+                                    <td>{{printf "%.2f" .Strike}}</td>
                                     <td>{{printf "%.2f" (.CalculatePercentOTM $.Price)}}%</td>
                                     <td>{{.Expiration.Format "1/2/2006"}}</td>
                                     <td>
@@ -174,11 +174,11 @@
                                     </td>
                                     <td>
                                         {{$percentProfit := .CalculatePercentOfProfit}}
-                                        <span class="{{if lt $percentProfit 0.0}}negative{{else if gt $percentProfit 0.0}}positive{{else}}neutral-currency{{end}}">{{printf "%.0f" $percentProfit}}%</span>
+                                        <span class="{{if lt $percentProfit 0.0}}negative{{else if gt $percentProfit 0.0}}positive{{else}}neutral-currency{{end}}">{{printf "%.2f" $percentProfit}}%</span>
                                     </td>
                                     <td>
                                         {{$percentTime := .CalculatePercentOfTime}}
-                                        <span class="{{if lt $percentTime 0.0}}negative{{else if gt $percentTime 0.0}}positive{{else}}neutral-currency{{end}}">{{printf "%.0f" $percentTime}}%</span>
+                                        <span class="{{if lt $percentTime 0.0}}negative{{else if gt $percentTime 0.0}}positive{{else}}neutral-currency{{end}}">{{printf "%.2f" $percentTime}}%</span>
                                     </td>
                                     <td>
                                         {{$multiplier := .CalculateMultiplier}}

--- a/internal/web/templates/treasuries.html
+++ b/internal/web/templates/treasuries.html
@@ -37,7 +37,7 @@
                     </div>
                     <div class="summary-item">
                         <div class="summary-label">Currently Held</div>
-                        <div class="summary-value">${{printf "%.0f" .Summary.TotalBuyPrice}}</div>
+                        <div class="summary-value">${{printf "%.2f" .Summary.TotalBuyPrice}}</div>
                     </div>
                     <div class="summary-item">
                         <div class="summary-label">Active Positions</div>


### PR DESCRIPTION
**Motivation**

Values (e.g. strike prices, etc.) were being displayed using %.0f, which caused rounding to whole numbers (e.g., 9.50 showing as 10). This created confusion when reviewing option strikes and profit/loss data.

**Changes**

Updated formatting from %.0f → %.2f to preserve two decimal places.

Applied changes consistently across:

internal/models/symbol.go
internal/polygon/live_integration_test.go
internal/web/templates/symbol.html
internal/web/templates/options.html
internal/web/templates/treasuries.html

**Impact**

Strike prices and OTM values now display with proper precision (e.g., 9.50 instead of 10).

Improves readability and prevents rounding errors in financial data display.

No changes to underlying calculations — display-only fix.

**Testing**

Verified locally that option strikes now display with two decimal places.

Cross-checked in multiple templates to confirm consistent formatting.