### PR TITLE
Refactor market data provider integration and add support for multiple data sources

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,172 @@
+# Wheeler Development Instructions for AI Agents
+
+## Project Context
+Wheeler is a Go web application for tracking options trading strategies (particularly "wheel strategy"), with SQLite persistence and Polygon.io market data integration. The core domain involves sophisticated financial tracking: cash-secured puts, covered calls, stock assignments, dividends, and Treasury collateral management.
+
+## Architecture Overview
+
+### Service Layer Pattern (`internal/models/`)
+Each domain entity has a dedicated service struct wrapping the `*sql.DB`:
+- **OptionService**: Manages Put/Call lifecycle with automatic commission calculation ($0.65/contract)
+- **LongPositionService**: Tracks stock holdings from put assignments to call assignments
+- **SymbolService**: Maintains stock metadata (price, dividend, P/E ratio)
+- **TreasuryService**: Handles collateral with dynamic balance adjustments
+- **DividendService**: Records dividend payments and yield calculations
+- **MetricService**: Aggregates portfolio performance and P&L calculations
+
+Services use **ID-based CRUD** operations (`GetByID`, `Update`, `Delete`) for web-friendly REST patterns. Compound key fallbacks exist for backward compatibility but are deprecated.
+
+### Database Design (`internal/database/`)
+**Hybrid Primary Key Strategy**:
+- **Transactional tables** use `INTEGER PRIMARY KEY AUTOINCREMENT` for easier HTTP operations: `options.id`, `long_positions.id`, `dividends.id`
+- **Reference tables** use natural keys: `symbols.symbol`, `treasuries.cuspid`, `settings.name`
+- **Unique constraints** prevent duplicate business records (e.g., same option opened twice)
+
+**Schema Management**:
+- `schema.sql` is the single source of truth (embedded via `//go:embed`)
+- No migration files; database setup uses `CREATE TABLE IF NOT EXISTS`
+- SQLite WAL mode with foreign keys enabled: `?_busy_timeout=10000&_journal_mode=WAL&_foreign_keys=on`
+
+### Web Layer (`internal/web/`)
+**Handler Organization**:
+- `server.go`: Server struct initialization, routing, template loading with custom functions
+- `*_handlers.go`: Domain-specific handlers (dashboard, options, symbols, etc.)
+- `types.go`: Web-specific data structures for JSON API responses
+- `utility_handlers.go`: Shared helper functions
+
+**Template Pattern**:
+- HTML templates in `templates/` use Go templating with custom functions (`groupByExpiration`, `add`, `mul`)
+- Shared component: `_symbol_modal.html` for reusable symbol entry
+- Chart.js for interactive visualizations (scatter plots, pie charts with click navigation)
+
+### External Integration (`internal/polygon/`)
+- `client.go`: HTTP client wrapping Polygon.io REST API
+- `service.go`: Business logic layer for fetching quotes, aggregates, and ticker details
+- API key stored in `settings` table, retrieved via `SettingService`
+
+## Development Commands
+
+### Quick Start
+```bash
+go run main.go                    # Start web server on :8080
+make build                        # Build to bin/wheeler with CGO enabled
+make test                         # Run all tests (requires CGO for SQLite)
+```
+
+### Database Operations
+- **Multiple databases**: Current DB tracked in `./data/currentdb` file
+- **Test data**: Click "Generate Test Data" in Help → Tutorial (loads `wheel_strategy_example.sql`)
+- **Backups**: Manual backup via Admin page saves to `./data/backups/`
+
+### Testing
+- Unit tests alongside code files (`*_test.go`)
+- Integration tests require live Polygon.io API key: `internal/polygon/live_integration_test.go`
+- Test databases automatically cleaned: `rm -f test_*.db`
+
+## Key Patterns & Conventions
+
+### Financial Calculations
+```go
+// Options commission is always $0.65 per contract
+const OptionCommissionPerContract = 0.65
+
+// P&L calculation includes commission deductions
+profit := (premium - exitPrice) * float64(contracts) * 100 - commission
+```
+
+### Service Method Signatures
+```go
+// ID-based operations (preferred)
+func (s *OptionService) GetByID(id int) (*Option, error)
+func (s *OptionService) Update(id int, updates map[string]interface{}) error
+
+// Compound key fallbacks (legacy compatibility)
+func (s *OptionService) GetByCompoundKey(symbol, type string, opened time.Time, ...) (*Option, error)
+```
+
+### Database Query Patterns
+```go
+// Always use prepared statements
+query := `UPDATE options SET exit_price = ?, closed = ? WHERE id = ?`
+_, err := s.db.Exec(query, exitPrice, time.Now(), optionID)
+
+// RETURNING clause for SQLite INSERT/UPDATE
+query := `INSERT INTO symbols (symbol, price) VALUES (?, ?) RETURNING symbol, price, created_at`
+err := s.db.QueryRow(query, symbol, price).Scan(&sym.Symbol, &sym.Price, &sym.CreatedAt)
+```
+
+### HTML Template Helpers
+```go
+// Custom template functions registered in server.go
+funcMap := template.FuncMap{
+    "groupByExpiration": groupPositionsByExpiration, // Groups options by expiration date
+    "add": func(a, b interface{}) interface{} { ... }, // Safe addition for mixed types
+}
+```
+
+### Wheel Strategy State Transitions
+```go
+// 1. Sell cash-secured put → Option record created (type="Put")
+// 2. Put assigned → LongPosition created, Treasury balance decreased
+// 3. Sell covered call → Option record created (type="Call")
+// 4. Call assigned → LongPosition closed, Treasury balance increased
+```
+
+## Important Context
+
+### Financial Domain Knowledge
+- **Option multiplier**: 1 contract = 100 shares (always multiply by 100 for cash calculations)
+- **Strike semantics**: Put assignment happens when stock price < strike; Call assignment when price > strike
+- **Premium collection**: Income earned upfront when selling options (both puts and calls)
+- **Collateral mechanics**: Treasury amounts dynamically adjust as options are assigned
+
+### Security Considerations
+- Never commit API keys; use `settings` table for Polygon.io key storage
+- Financial precision: Use `REAL` type in SQLite, not integers for monetary values
+- Input validation: All form inputs validated before database operations
+- SQL injection prevention: Always use prepared statements, never string concatenation
+
+### Project-Specific Quirks
+- Module name is `stonks` in `go.mod`, but project is called "Wheeler"
+- Database path resolution uses `./data/currentdb` file to track active database
+- CGO must be enabled for SQLite3 driver: `CGO_ENABLED=1 go build`
+- Port 8080 for development, 8077 for Docker (see `docker-compose.yml`)
+
+## Common Tasks
+
+### Adding New Domain Entity
+1. Create model struct in `internal/models/{entity}.go` with service pattern
+2. Add table schema to `internal/database/schema.sql`
+3. Implement CRUD methods: `Create`, `GetByID`, `Update`, `Delete`, `GetAll`
+4. Add handler in `internal/web/{entity}_handlers.go` with API endpoints
+5. Create HTML template in `internal/web/templates/{entity}.html`
+
+### Adding API Endpoint
+```go
+// In server.go
+func (s *Server) setupRoutes() {
+    http.HandleFunc("/api/entity/{id}", s.handleEntityAPI)
+}
+
+// Handler pattern (in handlers.go)
+func (s *Server) handleEntityAPI(w http.ResponseWriter, r *http.Request) {
+    switch r.Method {
+    case http.MethodGet: /* ... */
+    case http.MethodPut: /* ... */
+    case http.MethodDelete: /* ... */
+    }
+}
+```
+
+### Running Integration Tests
+```bash
+# Set API key via environment or settings table
+export POLYGON_API_KEY="your_key_here"
+go test -v ./internal/polygon/
+```
+
+## References
+- `CLAUDE.md`: Comprehensive development guidance (250+ lines)
+- `model.md`: Complete database schema specification
+- `README.md`: User-facing documentation and quick start
+- `internal/database/schema.sql`: Authoritative database structure

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,6 +27,16 @@ Services use **ID-based CRUD** operations (`GetByID`, `Update`, `Delete`) for we
 - No migration files; database setup uses `CREATE TABLE IF NOT EXISTS`
 - SQLite WAL mode with foreign keys enabled: `?_busy_timeout=10000&_journal_mode=WAL&_foreign_keys=on`
 
+### Market Data Providers (`internal/providers/`)
+- Defines a common interface and types for market data providers (quotes, aggregates, ticker metadata)
+- Application code depends on this abstraction rather than any specific vendor
+- New providers should implement this interface and be registered via the provider layer
+
+### Polygon Provider (`internal/polygon/`)
+- Default implementation of the market data provider interface using the Polygon.io REST API
+- `client.go`: HTTP client wrapper around Polygon.io endpoints
+- `service.go`: Business logic layer for fetching quotes, aggregates, and ticker details via the provider interface
+
 ### Web Layer (`internal/web/`)
 **Handler Organization**:
 - `server.go`: Server struct initialization, routing, template loading with custom functions

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,8 +23,8 @@ Services use **ID-based CRUD** operations (`GetByID`, `Update`, `Delete`) for we
 - **Unique constraints** prevent duplicate business records (e.g., same option opened twice)
 
 **Schema Management**:
-- `schema.sql` is the single source of truth (embedded via `//go:embed`)
-- No migration files; database setup uses `CREATE TABLE IF NOT EXISTS`
+- SQL migrations live in `internal/database/migrations/*.sql` and are embedded via `//go:embed`.
+- Migrations are the source of truth for schema changes; add new migrations for any schema update instead of modifying existing migrations or relying on ad-hoc `CREATE TABLE IF NOT EXISTS`.
 - SQLite WAL mode with foreign keys enabled: `?_busy_timeout=10000&_journal_mode=WAL&_foreign_keys=on`
 
 ### Market Data Providers (`internal/providers/`)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -49,17 +49,6 @@ Services use **ID-based CRUD** operations (`GetByID`, `Update`, `Delete`) for we
 - Shared component: `_symbol_modal.html` for reusable symbol entry
 - Chart.js for interactive visualizations (scatter plots, pie charts with click navigation)
 
-### Market Data Providers (`internal/providers/`)
-- Defines a common interface and types for market data providers (quotes, aggregates, ticker metadata)
-- Application code depends on this abstraction rather than any specific vendor
-- New providers should implement this interface and be registered via the provider layer
-
-### Polygon Provider (`internal/polygon/`)
-- Default implementation of the market data provider interface using the Polygon.io REST API
-- `client.go`: HTTP client wrapper around Polygon.io endpoints
-- `service.go`: Business logic layer for fetching quotes, aggregates, and ticker details via the provider interface
-- API key stored in `settings` table, retrieved via `SettingService`
-
 ## Development Commands
 
 ### Quick Start

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -49,9 +49,15 @@ Services use **ID-based CRUD** operations (`GetByID`, `Update`, `Delete`) for we
 - Shared component: `_symbol_modal.html` for reusable symbol entry
 - Chart.js for interactive visualizations (scatter plots, pie charts with click navigation)
 
-### External Integration (`internal/polygon/`)
-- `client.go`: HTTP client wrapping Polygon.io REST API
-- `service.go`: Business logic layer for fetching quotes, aggregates, and ticker details
+### Market Data Providers (`internal/providers/`)
+- Defines a common interface and types for market data providers (quotes, aggregates, ticker metadata)
+- Application code depends on this abstraction rather than any specific vendor
+- New providers should implement this interface and be registered via the provider layer
+
+### Polygon Provider (`internal/polygon/`)
+- Default implementation of the market data provider interface using the Polygon.io REST API
+- `client.go`: HTTP client wrapper around Polygon.io endpoints
+- `service.go`: Business logic layer for fetching quotes, aggregates, and ticker details via the provider interface
 - API key stored in `settings` table, retrieved via `SettingService`
 
 ## Development Commands

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,43 @@
 .claude
+
+# Local data files
 data/
+
+# Local env/secret files
+.env
+.env.*
+
+# Build artifacts
+bin/
+dist/
+tmp/
+coverage/
+
+# Logs
+*.log
+
+# Editor/OS
+.vscode/
+.idea/
+.DS_Store
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+
+# End of https://www.toptal.com/developers/gitignore/api/go

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .claude
-./data/.
+data/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,7 @@ The modern web interface provides comprehensive portfolio tracking:
 - `/api/allocation-data` - Portfolio allocation data for charts
 - `/api/generate-test-data` - Test data generation for tutorials
 - `/api/settings` - Application settings management
-- `/api/polygon/*` - Polygon.io API integration endpoints
+- `/api/provider/*` - Market data provider endpoints (connection tests, price refresh, dividend sync)
 
 ## Financial Domain Context
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,36 +14,79 @@ The project contains one main application:
 
 ## Development Commands
 
-### Web Dashboard (Primary Application)
-- **Run web dashboard**: `go run main.go` (starts on http://localhost:8080)
-- **Build web dashboard**: `go build . && ./wheeler`
+### Quick Start
+```bash
+go run main.go                    # Start web server on :8080
+make build                        # Build to bin/wheeler with CGO enabled
+make test                         # Run all tests (requires CGO for SQLite)
+```
 
 ### Database Operations
-- **Load test data**: Use the Generate Test Data buttons in Help → Tutorial
-- **Multiple databases**: Create/switch databases via Admin → Database
-- **Database backups**: Manual backups via Admin → Database page
+- **Multiple databases**: Current DB tracked in `./data/currentdb` file
+- **Test data**: Click "Generate Test Data" in Help → Tutorial (loads `wheel_strategy_example.sql`)
+- **Backups**: Manual backup via Admin page saves to `./data/backups/`
+
+### Testing
+- Unit tests alongside code files (`*_test.go`)
+- Integration tests in `test/` folder with consistent naming pattern
+- Integration tests require live Polygon.io API key: `internal/polygon/live_integration_test.go`
+- Test databases automatically cleaned: `rm -f test_*.db`
 
 ## Dependencies
 
 - Go 1.19+ with modules support
-- SQLite3 (`github.com/mattn/go-sqlite3`)
-- No GTK dependencies required for web dashboard
-- Web technologies: HTML5, CSS3, JavaScript, Chart.js
+- SQLite3 (`github.com/mattn/go-sqlite3`) - requires CGO
+- Chart.js for interactive visualizations
+- Standard library: `database/sql`, `net/http`, `html/template`
+- No GTK or external UI framework dependencies for web dashboard
 
-## Architecture Notes
+## Architecture Overview
 
-Key architectural decisions and patterns:
+Wheeler follows a layered architecture with clear separation of concerns:
 
-- **Primary Stack**: Go + Web Frontend + SQLite database
-- **Data Models**: Symbols, options, long positions, dividends, treasuries (see model.md)
-- **Database Design**: 
-  - INTEGER PRIMARY KEY AUTOINCREMENT for transactional data (options, long_positions, dividends)
-  - Natural primary keys for reference data (symbols.symbol, treasuries.cuspid)
-  - UNIQUE indexes to prevent duplicate business records
-  - Foreign key relationships for data integrity
-- **Web Interface**: HTML templates with Chart.js visualizations and AJAX APIs
-- **Service Layer**: ID-based CRUD operations with compound key fallbacks for compatibility
-- **API Design**: RESTful endpoints using integer IDs for easier HTTP operations
+### Service Layer Pattern (`internal/models/`)
+Each domain entity has a dedicated service struct wrapping the `*sql.DB`:
+- **OptionService**: Manages Put/Call lifecycle with automatic commission calculation ($0.65/contract)
+- **LongPositionService**: Tracks stock holdings from put assignments to call assignments
+- **SymbolService**: Maintains stock metadata (price, dividend, P/E ratio)
+- **TreasuryService**: Handles collateral with dynamic balance adjustments
+- **DividendService**: Records dividend payments and yield calculations
+- **MetricService**: Aggregates portfolio performance and P&L calculations
+
+Services use **ID-based CRUD** operations (`GetByID`, `Update`, `Delete`) for web-friendly REST patterns. Compound key fallbacks exist for backward compatibility but are deprecated.
+
+### Database Design (`internal/database/`)
+**Hybrid Primary Key Strategy**:
+- **Transactional tables** use `INTEGER PRIMARY KEY AUTOINCREMENT` for easier HTTP operations: `options.id`, `long_positions.id`, `dividends.id`
+- **Reference tables** use natural keys: `symbols.symbol`, `treasuries.cuspid`, `settings.name`
+- **Unique constraints** prevent duplicate business records (e.g., same option opened twice)
+
+**Schema Management**:
+- `schema.sql` is the single source of truth (embedded via `//go:embed`)
+- No migration files; database setup uses `CREATE TABLE IF NOT EXISTS`
+- SQLite WAL mode with foreign keys enabled: `?_busy_timeout=10000&_journal_mode=WAL&_foreign_keys=on`
+
+### Market Data Providers (`internal/providers/`)
+- Defines a common interface and types for market data providers (quotes, aggregates, ticker metadata)
+- Application code depends on this abstraction rather than any specific vendor
+- New providers should implement this interface and be registered via the provider layer
+
+### Polygon Provider (`internal/polygon/`)
+- Default implementation of the market data provider interface using the Polygon.io REST API
+- `client.go`: HTTP client wrapper around Polygon.io endpoints
+- `service.go`: Business logic layer for fetching quotes, aggregates, and ticker details via the provider interface
+
+### Web Layer (`internal/web/`)
+**Handler Organization**:
+- `server.go`: Server struct initialization, routing, template loading with custom functions
+- `*_handlers.go`: Domain-specific handlers (dashboard, options, symbols, etc.)
+- `types.go`: Web-specific data structures for JSON API responses
+- `utility_handlers.go`: Shared helper functions
+
+**Template Pattern**:
+- HTML templates in `templates/` use Go templating with custom functions (`groupByExpiration`, `add`, `mul`)
+- Shared component: `_symbol_modal.html` for reusable symbol entry
+- Chart.js for interactive visualizations (scatter plots, pie charts with click navigation)
 
 ## Web Dashboard Features
 
@@ -116,11 +159,73 @@ Wheeler specializes in sophisticated options trading strategies:
 
 ## Security Considerations
 
-- Never commit API keys for market data providers
-- Validate all financial calculations with appropriate precision
-- Follow security best practices for handling financial data
-- Use prepared statements for SQL operations to prevent injection
-- Validate form inputs before database operations
+- Never commit API keys; use `settings` table for Polygon.io key storage
+- Financial precision: Use `REAL` type in SQLite, not integers for monetary values
+- Input validation: All form inputs validated before database operations
+- SQL injection prevention: Always use prepared statements, never string concatenation
+
+## Key Patterns & Conventions
+
+### Financial Calculations
+```go
+// Options commission is always $0.65 per contract
+const OptionCommissionPerContract = 0.65
+
+// P&L calculation includes commission deductions
+profit := (premium - exitPrice) * float64(contracts) * 100 - commission
+```
+
+### Service Method Signatures
+```go
+// ID-based operations (preferred)
+func (s *OptionService) GetByID(id int) (*Option, error)
+func (s *OptionService) Update(id int, updates map[string]interface{}) error
+
+// Compound key fallbacks (legacy compatibility)
+func (s *OptionService) GetByCompoundKey(symbol, type string, opened time.Time, ...) (*Option, error)
+```
+
+### Database Query Patterns
+```go
+// Always use prepared statements
+query := `UPDATE options SET exit_price = ?, closed = ? WHERE id = ?`
+_, err := s.db.Exec(query, exitPrice, time.Now(), optionID)
+
+// RETURNING clause for SQLite INSERT/UPDATE
+query := `INSERT INTO symbols (symbol, price) VALUES (?, ?) RETURNING symbol, price, created_at`
+err := s.db.QueryRow(query, symbol, price).Scan(&sym.Symbol, &sym.Price, &sym.CreatedAt)
+```
+
+### HTML Template Helpers
+```go
+// Custom template functions registered in server.go
+funcMap := template.FuncMap{
+    "groupByExpiration": groupPositionsByExpiration, // Groups options by expiration date
+    "add": func(a, b interface{}) interface{} { ... }, // Safe addition for mixed types
+}
+```
+
+### Wheel Strategy State Transitions
+```go
+// 1. Sell cash-secured put → Option record created (type="Put")
+// 2. Put assigned → LongPosition created, Treasury balance decreased
+// 3. Sell covered call → Option record created (type="Call")
+// 4. Call assigned → LongPosition closed, Treasury balance increased
+```
+
+## Important Context
+
+### Financial Domain Knowledge
+- **Option multiplier**: 1 contract = 100 shares (always multiply by 100 for cash calculations)
+- **Strike semantics**: Put assignment happens when stock price < strike; Call assignment when price > strike
+- **Premium collection**: Income earned upfront when selling options (both puts and calls)
+- **Collateral mechanics**: Treasury amounts dynamically adjust as options are assigned
+
+### Project-Specific Quirks
+- Module name is `stonks` in `go.mod`, but project is called "Wheeler"
+- Database path resolution uses `./data/currentdb` file to track active database
+- CGO must be enabled for SQLite3 driver: `CGO_ENABLED=1 go build`
+- Port 8080 for development, 8077 for Docker (see `docker-compose.yml`)
 
 ## Project Structure
 
@@ -240,3 +345,80 @@ Wheeler supports multiple SQLite databases for different portfolios or environme
 - **Data Reset**: Switch databases or delete test database to start fresh
 
 To get started, use `go run main.go`, visit http://localhost:8080/help, switch to the Tutorial tab, and click "Generate Test Data" to see a complete wheel strategy implementation.
+
+## Common Tasks
+
+### Adding New Domain Entity
+1. Create model struct in `internal/models/{entity}.go` with service pattern
+2. Add table schema to `internal/database/schema.sql`
+3. Implement CRUD methods: `Create`, `GetByID`, `Update`, `Delete`, `GetAll`
+4. Add handler in `internal/web/{entity}_handlers.go` with API endpoints
+5. Create HTML template in `internal/web/templates/{entity}.html`
+
+### Adding API Endpoint
+```go
+// In server.go
+func (s *Server) setupRoutes() {
+    http.HandleFunc("/api/entity/{id}", s.handleEntityAPI)
+}
+
+// Handler pattern (in handlers.go)
+func (s *Server) handleEntityAPI(w http.ResponseWriter, r *http.Request) {
+    switch r.Method {
+    case http.MethodGet: /* ... */
+    case http.MethodPut: /* ... */
+    case http.MethodDelete: /* ... */
+    }
+}
+```
+
+### Running Integration Tests
+```bash
+# Set API key via environment or settings table
+export POLYGON_API_KEY="your_key_here"
+go test -v ./internal/polygon/
+```
+
+### Adding a New Data Provider
+1. Create a new provider implementation in `internal/providers/{provider_name}.go`
+2. Implement the `Provider` interface with all required methods:
+   - `GetQuote(ctx, symbol)` - Retrieve current quote data
+   - `GetTickerDetails(ctx, symbol)` - Get detailed ticker information
+   - `GetDividends(ctx, symbol, limit)` - Fetch dividend history
+   - `ValidateConnection(ctx)` - Test provider connectivity
+   - `Name()` - Return provider name
+3. Update `getProvider()` in `internal/providers/service.go` to support the new provider type
+4. Add settings entries for the new provider:
+   - `DATA_PROVIDER_TYPE` - Set to your provider name (e.g., "alphavantage")
+   - `{PROVIDER_NAME}_API_KEY` - API key for the new provider
+5. Update `GetAPIKeyStatus()` to handle the new provider's API key validation
+6. Add rate limiting logic in `GetRateLimitDelay()` if needed
+7. Create tests in `test/providers_test.go` for the new provider
+
+Example provider structure:
+```go
+type NewProvider struct {
+    apiKey string
+    client *http.Client
+}
+
+func NewNewProvider(apiKey string) *NewProvider {
+    return &NewProvider{
+        apiKey: apiKey,
+        client: &http.Client{Timeout: 30 * time.Second},
+    }
+}
+
+func (p *NewProvider) Name() string {
+    return "NewProvider"
+}
+
+// Implement remaining Provider interface methods...
+```
+
+## References
+- `.github/copilot-instructions.md`: AI agent development instructions
+- `CLAUDE.md`: AI agent development instructions
+- `model.md`: Complete database schema specification
+- `README.md`: User-facing documentation and quick start
+- `internal/database/schema.sql`: Authoritative database structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,8 +62,8 @@ Services use **ID-based CRUD** operations (`GetByID`, `Update`, `Delete`) for we
 - **Unique constraints** prevent duplicate business records (e.g., same option opened twice)
 
 **Schema Management**:
-- `schema.sql` is the single source of truth (embedded via `//go:embed`)
-- No migration files; database setup uses `CREATE TABLE IF NOT EXISTS`
+- `schema.sql` is the single source of truth (embedded via `//go:embed`) and defines the base schema
+- Incremental schema changes are managed via embedded SQL migrations in `internal/database/migrations/*.sql`, which are executed at startup
 - SQLite WAL mode with foreign keys enabled: `?_busy_timeout=10000&_journal_mode=WAL&_foreign_keys=on`
 
 ### Market Data Providers (`internal/providers/`)

--- a/internal/providers/README.md
+++ b/internal/providers/README.md
@@ -1,0 +1,159 @@
+# Data Provider System
+
+The Wheeler application uses a provider abstraction layer to support multiple market data sources. This design allows for easy integration of different data providers while maintaining a consistent interface.
+
+## Architecture
+
+### Provider Interface
+
+All market data providers must implement the `Provider` interface defined in `internal/providers/provider.go`:
+
+```go
+type Provider interface {
+    GetQuote(ctx context.Context, symbol string) (*Quote, error)
+    GetTickerDetails(ctx context.Context, symbol string) (*TickerDetails, error)
+    GetDividends(ctx context.Context, symbol string, limit int) ([]*Dividend, error)
+    ValidateConnection(ctx context.Context) error
+    Name() string
+}
+```
+
+### Current Providers
+
+- **Polygon.io** (`PolygonProvider`) - Default provider for stock market data
+
+## Adding a New Provider
+
+To add a new market data provider:
+
+### 1. Create Provider Implementation
+
+Create a new file in `internal/providers/` (e.g., `alphavantage.go`):
+
+```go
+package providers
+
+import (
+    "context"
+    "fmt"
+)
+
+type AlphaVantageProvider struct {
+    apiKey string
+    client *http.Client
+}
+
+func NewAlphaVantageProvider(apiKey string) *AlphaVantageProvider {
+    return &AlphaVantageProvider{
+        apiKey: apiKey,
+        client: &http.Client{Timeout: 30 * time.Second},
+    }
+}
+
+// Implement all Provider interface methods
+func (p *AlphaVantageProvider) GetQuote(ctx context.Context, symbol string) (*Quote, error) {
+    // Implementation...
+}
+
+func (p *AlphaVantageProvider) GetTickerDetails(ctx context.Context, symbol string) (*TickerDetails, error) {
+    // Implementation...
+}
+
+func (p *AlphaVantageProvider) GetDividends(ctx context.Context, symbol string, limit int) ([]*Dividend, error) {
+    // Implementation...
+}
+
+func (p *AlphaVantageProvider) ValidateConnection(ctx context.Context) error {
+    // Implementation...
+}
+
+func (p *AlphaVantageProvider) Name() string {
+    return "Alpha Vantage"
+}
+```
+
+### 2. Update Service Configuration
+
+Modify `internal/providers/service.go` to support provider selection:
+
+```go
+func (s *Service) getProvider() (Provider, error) {
+    providerType := s.settingService.GetValue("DATA_PROVIDER_TYPE")
+    
+    switch providerType {
+    case "alphavantage":
+        apiKey := s.settingService.GetValue("ALPHAVANTAGE_API_KEY")
+        return NewAlphaVantageProvider(apiKey), nil
+    case "polygon":
+        fallthrough
+    default:
+        apiKey := s.settingService.GetValue("POLYGON_API_KEY")
+        return NewPolygonProvider(apiKey), nil
+    }
+}
+```
+
+### 3. Add Settings Management
+
+Add settings for the new provider:
+- API key storage
+- Provider selection UI
+- Configuration validation
+
+### 4. Write Tests
+
+Create unit tests for the new provider:
+
+```go
+func TestAlphaVantageProvider(t *testing.T) {
+    provider := NewAlphaVantageProvider("test-key")
+    
+    ctx := context.Background()
+    quote, err := provider.GetQuote(ctx, "AAPL")
+    // Test assertions...
+}
+```
+
+### 5. Update Documentation
+
+- Update this README with provider-specific information
+- Add any rate limiting considerations
+- Document API key requirements
+
+## Provider Standards
+
+All providers should:
+1. **Handle errors gracefully** - Return descriptive errors for API failures
+2. **Respect rate limits** - Implement appropriate throttling
+3. **Cache when appropriate** - Avoid redundant API calls
+4. **Log operations** - Use structured logging for debugging
+5. **Validate inputs** - Check symbols and parameters before API calls
+6. **Context awareness** - Support cancellation via context
+
+## Rate Limiting
+
+Each provider should implement appropriate rate limiting:
+- Polygon.io Free Tier: 5 requests/minute (implemented in `Service.UpdateAllSymbolPrices`)
+- Add your provider's limits in the implementation
+
+## Error Handling
+
+Providers should wrap errors with context:
+```go
+return nil, fmt.Errorf("polygon: failed to fetch quote: %w", err)
+```
+
+This helps identify which provider caused an error in logs.
+
+## Testing
+
+Run provider tests:
+```bash
+go test ./internal/providers/
+```
+
+For integration tests with live APIs, set environment variables:
+```bash
+export POLYGON_API_KEY="your-key"
+go test ./internal/providers/ -v
+```

--- a/internal/providers/README.md
+++ b/internal/providers/README.md
@@ -132,10 +132,10 @@ All providers should:
 
 ## Rate Limiting
 
-Each provider should implement appropriate rate limiting:
-- Polygon.io Free Tier: 5 requests/minute (implemented in `Service.UpdateAllSymbolPrices`)
-- Add your provider's limits in the implementation
+Rate limiting is enforced centrally in the service layer via the shared `waitForRateLimit` / `runPriceUpdates` path, which throttles both price and dividend fetches.
 
+- Polygon.io Free Tier: 5 requests/minute (enforced via the shared rate-limiting pipeline)
+- When adding a new provider, document its limits and either reuse the shared rate limiter or add provider-specific safeguards where necessary
 ## Error Handling
 
 Providers should wrap errors with context:

--- a/internal/providers/polygon.go
+++ b/internal/providers/polygon.go
@@ -1,0 +1,94 @@
+package providers
+
+import (
+	"context"
+	"fmt"
+	"stonks/internal/polygon"
+	"time"
+)
+
+// PolygonProvider implements the Provider interface using Polygon.io
+type PolygonProvider struct {
+	client *polygon.Client
+}
+
+// NewPolygonProvider creates a new Polygon.io provider
+func NewPolygonProvider(apiKey string) *PolygonProvider {
+	return &PolygonProvider{
+		client: polygon.NewClient(apiKey),
+	}
+}
+
+// GetQuote retrieves the current or most recent quote for a symbol
+func (p *PolygonProvider) GetQuote(ctx context.Context, symbol string) (*Quote, error) {
+	polygonQuote, err := p.client.GetPreviousClose(ctx, symbol)
+	if err != nil {
+		return nil, fmt.Errorf("polygon: %w", err)
+	}
+
+	return &Quote{
+		Symbol:        polygonQuote.Results.Symbol,
+		Price:         polygonQuote.Results.Price,
+		Open:          polygonQuote.Results.Open,
+		High:          polygonQuote.Results.High,
+		Low:           polygonQuote.Results.Low,
+		Volume:        polygonQuote.Results.Volume,
+		PreviousClose: polygonQuote.Results.PreviousClose,
+		Timestamp:     time.Unix(0, polygonQuote.Results.Timestamp*int64(time.Millisecond)),
+	}, nil
+}
+
+// GetTickerDetails retrieves detailed information about a ticker
+func (p *PolygonProvider) GetTickerDetails(ctx context.Context, symbol string) (*TickerDetails, error) {
+	details, err := p.client.GetTickerDetails(ctx, symbol)
+	if err != nil {
+		return nil, fmt.Errorf("polygon: %w", err)
+	}
+
+	return &TickerDetails{
+		Symbol:      details.Results.Symbol,
+		Name:        details.Results.Name,
+		Market:      details.Results.Market,
+		Type:        details.Results.Type,
+		Active:      details.Results.Active,
+		Currency:    details.Results.CurrencyName,
+		Description: details.Results.Description,
+		Homepage:    details.Results.HomepageURL,
+		MarketCap:   details.Results.MarketCap,
+		Employees:   details.Results.TotalEmployees,
+	}, nil
+}
+
+// GetDividends retrieves dividend history for a symbol
+func (p *PolygonProvider) GetDividends(ctx context.Context, symbol string, limit int) ([]*Dividend, error) {
+	dividends, err := p.client.GetDividends(ctx, symbol, limit)
+	if err != nil {
+		return nil, fmt.Errorf("polygon: %w", err)
+	}
+
+	result := make([]*Dividend, 0, len(dividends.Results))
+	for _, div := range dividends.Results {
+		result = append(result, &Dividend{
+			Symbol:          div.Ticker,
+			CashAmount:      div.CashAmount,
+			DeclarationDate: div.DeclarationDate,
+			ExDividendDate:  div.ExDividendDate,
+			PayDate:         div.PayDate,
+			RecordDate:      div.RecordDate,
+			DividendType:    div.DividendType,
+			Frequency:       div.Frequency,
+		})
+	}
+
+	return result, nil
+}
+
+// ValidateConnection tests if the provider connection is working
+func (p *PolygonProvider) ValidateConnection(ctx context.Context) error {
+	return p.client.IsValidAPIKey(ctx)
+}
+
+// Name returns the provider's name
+func (p *PolygonProvider) Name() string {
+	return "Polygon.io"
+}

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -1,0 +1,62 @@
+package providers
+
+import (
+	"context"
+	"time"
+)
+
+// Provider defines the interface for market data providers
+type Provider interface {
+	// GetQuote retrieves the current or most recent quote for a symbol
+	GetQuote(ctx context.Context, symbol string) (*Quote, error)
+	
+	// GetTickerDetails retrieves detailed information about a ticker
+	GetTickerDetails(ctx context.Context, symbol string) (*TickerDetails, error)
+	
+	// GetDividends retrieves dividend history for a symbol
+	GetDividends(ctx context.Context, symbol string, limit int) ([]*Dividend, error)
+	
+	// ValidateConnection tests if the provider connection is working
+	ValidateConnection(ctx context.Context) error
+	
+	// Name returns the provider's name
+	Name() string
+}
+
+// Quote represents a stock quote from any provider
+type Quote struct {
+	Symbol        string
+	Price         float64
+	Open          float64
+	High          float64
+	Low           float64
+	Volume        float64
+	PreviousClose float64
+	Timestamp     time.Time
+}
+
+// TickerDetails represents detailed ticker information from any provider
+type TickerDetails struct {
+	Symbol      string
+	Name        string
+	Market      string
+	Type        string
+	Active      bool
+	Currency    string
+	Description string
+	Homepage    string
+	MarketCap   float64
+	Employees   int
+}
+
+// Dividend represents dividend information from any provider
+type Dividend struct {
+	Symbol          string
+	CashAmount      float64
+	DeclarationDate string
+	ExDividendDate  string
+	PayDate         string
+	RecordDate      string
+	DividendType    string
+	Frequency       int
+}

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -9,16 +9,15 @@ import (
 type Provider interface {
 	// GetQuote retrieves the current or most recent quote for a symbol
 	GetQuote(ctx context.Context, symbol string) (*Quote, error)
-	
+
 	// GetTickerDetails retrieves detailed information about a ticker
 	GetTickerDetails(ctx context.Context, symbol string) (*TickerDetails, error)
-	
+
 	// GetDividends retrieves dividend history for a symbol
 	GetDividends(ctx context.Context, symbol string, limit int) ([]*Dividend, error)
-	
+
 	// ValidateConnection tests if the provider connection is working
 	ValidateConnection(ctx context.Context) error
-	
 	// Name returns the provider's name
 	Name() string
 }

--- a/internal/providers/provider_test.go
+++ b/internal/providers/provider_test.go
@@ -59,6 +59,17 @@ func TestProviderInterface(t *testing.T) {
 	}
 
 	// Test GetQuote
+	// Test with custom quote function
+	mock.quoteFunc = func(ctx context.Context, symbol string) (*Quote, error) {
+		return &Quote{Symbol: symbol, Price: 150.5}, nil
+	}
+	quote, err = mock.GetQuote(ctx, "TSLA")
+	if err != nil {
+		t.Fatalf("GetQuote with custom func failed: %v", err)
+	}
+	if quote.Price != 150.5 {
+		t.Errorf("Expected custom price 150.5, got %.2f", quote.Price)
+	}
 	quote, err := mock.GetQuote(ctx, "AAPL")
 	if err != nil {
 		t.Fatalf("GetQuote failed: %v", err)

--- a/internal/providers/provider_test.go
+++ b/internal/providers/provider_test.go
@@ -1,0 +1,95 @@
+package providers
+
+import (
+	"context"
+	"testing"
+)
+
+// MockProvider implements Provider interface for testing
+type MockProvider struct {
+	name            string
+	quoteFunc       func(ctx context.Context, symbol string) (*Quote, error)
+	detailsFunc     func(ctx context.Context, symbol string) (*TickerDetails, error)
+	dividendsFunc   func(ctx context.Context, symbol string, limit int) ([]*Dividend, error)
+	validateFunc    func(ctx context.Context) error
+}
+
+func (m *MockProvider) GetQuote(ctx context.Context, symbol string) (*Quote, error) {
+	if m.quoteFunc != nil {
+		return m.quoteFunc(ctx, symbol)
+	}
+	return &Quote{Symbol: symbol, Price: 100.0}, nil
+}
+
+func (m *MockProvider) GetTickerDetails(ctx context.Context, symbol string) (*TickerDetails, error) {
+	if m.detailsFunc != nil {
+		return m.detailsFunc(ctx, symbol)
+	}
+	return &TickerDetails{Symbol: symbol, Name: "Test Company"}, nil
+}
+
+func (m *MockProvider) GetDividends(ctx context.Context, symbol string, limit int) ([]*Dividend, error) {
+	if m.dividendsFunc != nil {
+		return m.dividendsFunc(ctx, symbol, limit)
+	}
+	return []*Dividend{{Symbol: symbol, CashAmount: 1.0}}, nil
+}
+
+func (m *MockProvider) ValidateConnection(ctx context.Context) error {
+	if m.validateFunc != nil {
+		return m.validateFunc(ctx)
+	}
+	return nil
+}
+
+func (m *MockProvider) Name() string {
+	if m.name != "" {
+		return m.name
+	}
+	return "MockProvider"
+}
+
+func TestProviderInterface(t *testing.T) {
+	ctx := context.Background()
+	mock := &MockProvider{name: "TestProvider"}
+
+	// Test Name
+	if name := mock.Name(); name != "TestProvider" {
+		t.Errorf("Expected name 'TestProvider', got '%s'", name)
+	}
+
+	// Test GetQuote
+	quote, err := mock.GetQuote(ctx, "AAPL")
+	if err != nil {
+		t.Fatalf("GetQuote failed: %v", err)
+	}
+	if quote.Symbol != "AAPL" {
+		t.Errorf("Expected symbol 'AAPL', got '%s'", quote.Symbol)
+	}
+	if quote.Price != 100.0 {
+		t.Errorf("Expected price 100.0, got %.2f", quote.Price)
+	}
+
+	// Test GetTickerDetails
+	details, err := mock.GetTickerDetails(ctx, "AAPL")
+	if err != nil {
+		t.Fatalf("GetTickerDetails failed: %v", err)
+	}
+	if details.Symbol != "AAPL" {
+		t.Errorf("Expected symbol 'AAPL', got '%s'", details.Symbol)
+	}
+
+	// Test GetDividends
+	dividends, err := mock.GetDividends(ctx, "AAPL", 10)
+	if err != nil {
+		t.Fatalf("GetDividends failed: %v", err)
+	}
+	if len(dividends) != 1 {
+		t.Errorf("Expected 1 dividend, got %d", len(dividends))
+	}
+
+	// Test ValidateConnection
+	if err := mock.ValidateConnection(ctx); err != nil {
+		t.Errorf("ValidateConnection failed: %v", err)
+	}
+}

--- a/internal/providers/provider_test.go
+++ b/internal/providers/provider_test.go
@@ -49,6 +49,8 @@ func (m *MockProvider) Name() string {
 	return "MockProvider"
 }
 
+var _ Provider = (*PolygonProvider)(nil)
+
 func TestProviderInterface(t *testing.T) {
 	ctx := context.Background()
 	mock := &MockProvider{name: "TestProvider"}

--- a/internal/providers/provider_test.go
+++ b/internal/providers/provider_test.go
@@ -7,11 +7,11 @@ import (
 
 // MockProvider implements Provider interface for testing
 type MockProvider struct {
-	name            string
-	quoteFunc       func(ctx context.Context, symbol string) (*Quote, error)
-	detailsFunc     func(ctx context.Context, symbol string) (*TickerDetails, error)
-	dividendsFunc   func(ctx context.Context, symbol string, limit int) ([]*Dividend, error)
-	validateFunc    func(ctx context.Context) error
+	name          string
+	quoteFunc     func(ctx context.Context, symbol string) (*Quote, error)
+	detailsFunc   func(ctx context.Context, symbol string) (*TickerDetails, error)
+	dividendsFunc func(ctx context.Context, symbol string, limit int) ([]*Dividend, error)
+	validateFunc  func(ctx context.Context) error
 }
 
 func (m *MockProvider) GetQuote(ctx context.Context, symbol string) (*Quote, error) {
@@ -59,6 +59,17 @@ func TestProviderInterface(t *testing.T) {
 	}
 
 	// Test GetQuote
+	quote, err := mock.GetQuote(ctx, "AAPL")
+	if err != nil {
+		t.Fatalf("GetQuote failed: %v", err)
+	}
+	if quote.Symbol != "AAPL" {
+		t.Errorf("Expected symbol 'AAPL', got '%s'", quote.Symbol)
+	}
+	if quote.Price != 100.0 {
+		t.Errorf("Expected price 100.0, got %.2f", quote.Price)
+	}
+
 	// Test with custom quote function
 	mock.quoteFunc = func(ctx context.Context, symbol string) (*Quote, error) {
 		return &Quote{Symbol: symbol, Price: 150.5}, nil
@@ -69,16 +80,6 @@ func TestProviderInterface(t *testing.T) {
 	}
 	if quote.Price != 150.5 {
 		t.Errorf("Expected custom price 150.5, got %.2f", quote.Price)
-	}
-	quote, err := mock.GetQuote(ctx, "AAPL")
-	if err != nil {
-		t.Fatalf("GetQuote failed: %v", err)
-	}
-	if quote.Symbol != "AAPL" {
-		t.Errorf("Expected symbol 'AAPL', got '%s'", quote.Symbol)
-	}
-	if quote.Price != 100.0 {
-		t.Errorf("Expected price 100.0, got %.2f", quote.Price)
 	}
 
 	// Test GetTickerDetails

--- a/internal/providers/provider_test.go
+++ b/internal/providers/provider_test.go
@@ -49,7 +49,7 @@ func (m *MockProvider) Name() string {
 	return "MockProvider"
 }
 
-var _ Provider = (*PolygonProvider)(nil)
+var _ Provider = (*MockProvider)(nil)
 
 func TestProviderInterface(t *testing.T) {
 	ctx := context.Background()

--- a/internal/providers/service.go
+++ b/internal/providers/service.go
@@ -31,7 +31,7 @@ func (s *Service) getProvider() (Provider, error) {
 	if providerType == "" {
 		providerType = "polygon"
 	}
-	providerType = strings.ToLower(providerType)
+	providerType = strings.ToLower(strings.TrimSpace(providerType))
 
 	switch providerType {
 	case "polygon":
@@ -48,7 +48,7 @@ func (s *Service) getProvider() (Provider, error) {
 			} else {
 				maskedKey = "***"
 			}
-			log.Printf("[PROVIDER] Using %s provider with API key: %s", strings.ToUpper(providerType), maskedKey)
+			log.Printf("[PROVIDER] Using %s provider with API key: %s (DEBUG_PROVIDERS=1 - do not enable in production)", strings.ToUpper(providerType), maskedKey)
 		}
 
 		return NewPolygonProvider(apiKey), nil
@@ -125,8 +125,16 @@ func (s *Service) UpdateAllSymbolPrices(ctx context.Context) error {
 			updated++
 		}
 
-		// Rate limiting to respect provider API limits
-		time.Sleep(rateLimitDelay)
+		// Rate limiting to respect provider API limits, while honoring context cancellation
+		if rateLimitDelay > 0 {
+			select {
+			case <-ctx.Done():
+				log.Printf("[PROVIDER] Prioritized bulk price update canceled during rate limiting: %v", ctx.Err())
+				return ctx.Err()
+			case <-time.After(rateLimitDelay):
+				// continue to next symbol
+			}
+		}
 	}
 
 	log.Printf("[PROVIDER] Prioritized bulk price update complete: %d updated, %d failed", updated, failed)
@@ -268,13 +276,9 @@ func (s *Service) Name() string {
 		providerType = "polygon"
 	}
 
-	switch providerType {
-	case "polygon":
-		return "Polygon.io"
-	default:
-		return strings.Title(providerType)
-	}
+	return providerType
 }
+
 
 // GetRateLimitDelay returns the rate limit delay based on the configured provider
 func (s *Service) GetRateLimitDelay() time.Duration {

--- a/internal/providers/service.go
+++ b/internal/providers/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"stonks/internal/models"
 	"strings"
 	"time"
@@ -11,7 +12,6 @@ import (
 
 // Service provides market data integration for Wheeler using provider abstraction
 type Service struct {
-	provider       Provider
 	symbolService  *models.SymbolService
 	settingService *models.SettingService
 }
@@ -40,14 +40,16 @@ func (s *Service) getProvider() (Provider, error) {
 			return nil, fmt.Errorf("Polygon API key not configured - please set your API key in Settings")
 		}
 
-		// Log masked API key for debugging
-		var maskedKey string
-		if len(apiKey) > 6 {
-			maskedKey = apiKey[:3] + "..." + apiKey[len(apiKey)-3:]
-		} else {
-			maskedKey = "***"
+		// Optionally log masked API key for debugging when DEBUG_PROVIDERS is enabled
+		if os.Getenv("DEBUG_PROVIDERS") == "1" {
+			var maskedKey string
+			if len(apiKey) > 6 {
+				maskedKey = apiKey[:3] + "..." + apiKey[len(apiKey)-3:]
+			} else {
+				maskedKey = "***"
+			}
+			log.Printf("[PROVIDER] Using %s provider with API key: %s", strings.ToUpper(providerType), maskedKey)
 		}
-		log.Printf("[PROVIDER] Using %s provider with API key: %s", strings.ToUpper(providerType), maskedKey)
 
 		return NewPolygonProvider(apiKey), nil
 	default:
@@ -62,6 +64,11 @@ func (s *Service) UpdateSymbolPrice(ctx context.Context, symbol string) error {
 		return fmt.Errorf("failed to get provider: %w", err)
 	}
 
+	return s.updateSymbolPriceWithProvider(ctx, provider, symbol)
+}
+
+// updateSymbolPriceWithProvider updates a single symbol's price using a pre-fetched provider
+func (s *Service) updateSymbolPriceWithProvider(ctx context.Context, provider Provider, symbol string) error {
 	log.Printf("[PROVIDER] Updating price for symbol: %s using %s", symbol, provider.Name())
 
 	// Get current price from provider
@@ -106,17 +113,20 @@ func (s *Service) UpdateAllSymbolPrices(ctx context.Context) error {
 
 	log.Printf("[PROVIDER] Starting prioritized bulk price update for %d symbols using %s", len(symbols), provider.Name())
 
+	// Get rate limit configuration from provider (or use default)
+	rateLimitDelay := s.GetRateLimitDelay()
+
 	var updated, failed int
 	for _, symbol := range symbols {
-		if err := s.UpdateSymbolPrice(ctx, symbol); err != nil {
+		if err := s.updateSymbolPriceWithProvider(ctx, provider, symbol); err != nil {
 			log.Printf("[PROVIDER] Failed to update %s: %v", symbol, err)
 			failed++
 		} else {
 			updated++
 		}
 
-		// Rate limiting: Polygon.io Free tier allows 5 requests per minute (approx. 1 request every 12 seconds)
-		time.Sleep(12 * time.Second)
+		// Rate limiting to respect provider API limits
+		time.Sleep(rateLimitDelay)
 	}
 
 	log.Printf("[PROVIDER] Prioritized bulk price update complete: %d updated, %d failed", updated, failed)
@@ -211,22 +221,61 @@ func (s *Service) TestConnection(ctx context.Context) error {
 
 // GetAPIKeyStatus returns information about the current API key configuration
 func (s *Service) GetAPIKeyStatus() *APIKeyStatus {
-	apiKey := s.settingService.GetValue("POLYGON_API_KEY")
-	
+	providerType := strings.ToLower(strings.TrimSpace(s.settingService.GetValue("DATA_PROVIDER_TYPE")))
+	if providerType == "" {
+		providerType = "polygon" // Default to Polygon for backwards compatibility
+	}
+
+	var apiKey string
+
+	switch providerType {
+	case "polygon":
+		apiKey = s.settingService.GetValue("POLYGON_API_KEY")
+		// Add additional providers here as they are supported, for example:
+		// case "alpaca":
+		//     apiKey = s.settingService.GetValue("ALPACA_API_KEY")
+	default:
+		// Unknown or unsupported provider type; report as not configured
+		return &APIKeyStatus{
+			Configured: false,
+			Masked:     "",
+		}
+	}
+
 	status := &APIKeyStatus{
 		Configured: apiKey != "",
 		Masked:     "",
 	}
 
-	if status.Configured {
-		if len(apiKey) > 6 {
-			status.Masked = apiKey[:3] + "..." + apiKey[len(apiKey)-3:]
-		} else {
-			status.Masked = strings.Repeat("*", len(apiKey))
-		}
+	if !status.Configured {
+		return status
+	}
+
+	// Mask the API key so only a small portion is visible
+	if len(apiKey) > 6 {
+		status.Masked = apiKey[:3] + "..." + apiKey[len(apiKey)-3:]
+	} else {
+		status.Masked = strings.Repeat("*", len(apiKey))
 	}
 
 	return status
+}
+
+// getRateLimitDelay returns the rate limit delay based on the configured provider
+func (s *Service) GetRateLimitDelay() time.Duration {
+	providerType := strings.ToLower(strings.TrimSpace(s.settingService.GetValue("DATA_PROVIDER_TYPE")))
+	if providerType == "" {
+		providerType = "polygon"
+	}
+
+	switch providerType {
+	case "polygon":
+		// Polygon.io Free tier allows 5 requests per minute (approx. 1 request every 12 seconds)
+		return 12 * time.Second
+	default:
+		// Conservative default for unknown providers
+		return 10 * time.Second
+	}
 }
 
 // SymbolInfo represents enriched symbol information from a provider

--- a/internal/providers/service.go
+++ b/internal/providers/service.go
@@ -279,7 +279,6 @@ func (s *Service) Name() string {
 	return providerType
 }
 
-
 // GetRateLimitDelay returns the rate limit delay based on the configured provider
 func (s *Service) GetRateLimitDelay() time.Duration {
 	providerType := strings.ToLower(strings.TrimSpace(s.settingService.GetValue("DATA_PROVIDER_TYPE")))

--- a/internal/providers/service.go
+++ b/internal/providers/service.go
@@ -1,0 +1,257 @@
+package providers
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"stonks/internal/models"
+	"strings"
+	"time"
+)
+
+// Service provides market data integration for Wheeler using provider abstraction
+type Service struct {
+	provider       Provider
+	symbolService  *models.SymbolService
+	settingService *models.SettingService
+}
+
+// NewService creates a new provider service with the default provider
+func NewService(symbolService *models.SymbolService, settingService *models.SettingService) *Service {
+	return &Service{
+		symbolService:  symbolService,
+		settingService: settingService,
+	}
+}
+
+// getProvider returns the configured provider with API key
+func (s *Service) getProvider() (Provider, error) {
+	apiKey := s.settingService.GetValue("POLYGON_API_KEY")
+	if apiKey == "" {
+		return nil, fmt.Errorf("Polygon API key not configured - please set your API key in Settings")
+	}
+
+	// Log masked API key for debugging
+	var maskedKey string
+	if len(apiKey) > 6 {
+		maskedKey = apiKey[:3] + "..." + apiKey[len(apiKey)-3:]
+	} else {
+		maskedKey = "***"
+	}
+	log.Printf("[PROVIDER] Using API key: %s", maskedKey)
+
+	return NewPolygonProvider(apiKey), nil
+}
+
+// UpdateSymbolPrice updates a single symbol's price from the configured provider
+func (s *Service) UpdateSymbolPrice(ctx context.Context, symbol string) error {
+	provider, err := s.getProvider()
+	if err != nil {
+		return fmt.Errorf("failed to get provider: %w", err)
+	}
+
+	log.Printf("[PROVIDER] Updating price for symbol: %s using %s", symbol, provider.Name())
+
+	// Get current price from provider
+	quote, err := provider.GetQuote(ctx, symbol)
+	if err != nil {
+		return fmt.Errorf("failed to get quote for %s: %w", symbol, err)
+	}
+
+	// Get current symbol data
+	currentSymbol, err := s.symbolService.GetBySymbol(symbol)
+	if err != nil {
+		return fmt.Errorf("failed to get current symbol data: %w", err)
+	}
+
+	// Update symbol with new price
+	_, err = s.symbolService.Update(
+		symbol,
+		quote.Price,
+		currentSymbol.Dividend,
+		currentSymbol.ExDividendDate,
+		currentSymbol.PERatio,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to update symbol price: %w", err)
+	}
+
+	log.Printf("[PROVIDER] Updated %s price to $%.2f", symbol, quote.Price)
+	return nil
+}
+
+// UpdateAllSymbolPrices updates prices for all symbols in the database
+func (s *Service) UpdateAllSymbolPrices(ctx context.Context) error {
+	symbols, err := s.symbolService.GetPrioritizedSymbols()
+	if err != nil {
+		return fmt.Errorf("failed to get prioritized symbols: %w", err)
+	}
+
+	provider, err := s.getProvider()
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[PROVIDER] Starting prioritized bulk price update for %d symbols using %s", len(symbols), provider.Name())
+
+	var updated, failed int
+	for _, symbol := range symbols {
+		if err := s.UpdateSymbolPrice(ctx, symbol); err != nil {
+			log.Printf("[PROVIDER] Failed to update %s: %v", symbol, err)
+			failed++
+		} else {
+			updated++
+		}
+
+		// Rate limiting: Free tier allows 5 requests per minute
+		time.Sleep(12 * time.Second)
+	}
+
+	log.Printf("[PROVIDER] Prioritized bulk price update complete: %d updated, %d failed", updated, failed)
+	return nil
+}
+
+// FetchSymbolDetails gets detailed information about a symbol from the provider
+func (s *Service) FetchSymbolDetails(ctx context.Context, symbol string) (*SymbolInfo, error) {
+	provider, err := s.getProvider()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get provider: %w", err)
+	}
+
+	details, err := provider.GetTickerDetails(ctx, symbol)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ticker details: %w", err)
+	}
+
+	quote, err := provider.GetQuote(ctx, symbol)
+	if err != nil {
+		log.Printf("[PROVIDER] Warning: failed to get current price for %s: %v", symbol, err)
+		// Continue without current price
+	}
+
+	info := &SymbolInfo{
+		Symbol:      details.Symbol,
+		Name:        details.Name,
+		Market:      details.Market,
+		Type:        details.Type,
+		Active:      details.Active,
+		Currency:    details.Currency,
+		Description: details.Description,
+		Homepage:    details.Homepage,
+		MarketCap:   details.MarketCap,
+		Employees:   details.Employees,
+	}
+
+	if quote != nil {
+		info.CurrentPrice = quote.Price
+		info.PreviousClose = quote.PreviousClose
+		info.High = quote.High
+		info.Low = quote.Low
+		info.Volume = quote.Volume
+	}
+
+	return info, nil
+}
+
+// FetchDividendHistory gets recent dividend history for a symbol
+func (s *Service) FetchDividendHistory(ctx context.Context, symbol string, limit int) ([]*DividendInfo, error) {
+	provider, err := s.getProvider()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get provider: %w", err)
+	}
+
+	if limit <= 0 {
+		limit = 10
+	}
+
+	dividends, err := provider.GetDividends(ctx, symbol, limit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dividends: %w", err)
+	}
+
+	var result []*DividendInfo
+	for _, div := range dividends {
+		info := &DividendInfo{
+			Symbol:          div.Symbol,
+			CashAmount:      div.CashAmount,
+			DeclarationDate: div.DeclarationDate,
+			ExDividendDate:  div.ExDividendDate,
+			PayDate:         div.PayDate,
+			RecordDate:      div.RecordDate,
+			DividendType:    div.DividendType,
+			Frequency:       div.Frequency,
+		}
+		result = append(result, info)
+	}
+
+	return result, nil
+}
+
+// TestConnection validates the provider connection
+func (s *Service) TestConnection(ctx context.Context) error {
+	provider, err := s.getProvider()
+	if err != nil {
+		return err
+	}
+
+	return provider.ValidateConnection(ctx)
+}
+
+// GetAPIKeyStatus returns information about the current API key configuration
+func (s *Service) GetAPIKeyStatus() *APIKeyStatus {
+	apiKey := s.settingService.GetValue("POLYGON_API_KEY")
+	
+	status := &APIKeyStatus{
+		Configured: apiKey != "",
+		Masked:     "",
+	}
+
+	if status.Configured {
+		if len(apiKey) > 6 {
+			status.Masked = apiKey[:3] + "..." + apiKey[len(apiKey)-3:]
+		} else {
+			status.Masked = strings.Repeat("*", len(apiKey))
+		}
+	}
+
+	return status
+}
+
+// SymbolInfo represents enriched symbol information from a provider
+type SymbolInfo struct {
+	Symbol        string  `json:"symbol"`
+	Name          string  `json:"name"`
+	Market        string  `json:"market"`
+	Type          string  `json:"type"`
+	Active        bool    `json:"active"`
+	Currency      string  `json:"currency"`
+	Description   string  `json:"description"`
+	Homepage      string  `json:"homepage"`
+	MarketCap     float64 `json:"market_cap"`
+	Employees     int     `json:"employees"`
+	CurrentPrice  float64 `json:"current_price"`
+	PreviousClose float64 `json:"previous_close"`
+	High          float64 `json:"high"`
+	Low           float64 `json:"low"`
+	Volume        float64 `json:"volume"`
+}
+
+// DividendInfo represents dividend information from a provider
+type DividendInfo struct {
+	Symbol          string  `json:"symbol"`
+	CashAmount      float64 `json:"cash_amount"`
+	DeclarationDate string  `json:"declaration_date"`
+	ExDividendDate  string  `json:"ex_dividend_date"`
+	PayDate         string  `json:"pay_date"`
+	RecordDate      string  `json:"record_date"`
+	DividendType    string  `json:"dividend_type"`
+	Frequency       int     `json:"frequency"`
+}
+
+// APIKeyStatus represents the status of the provider API key
+type APIKeyStatus struct {
+	Configured bool   `json:"configured"`
+	Masked     string `json:"masked"`
+	Valid      bool   `json:"valid"`
+	Error      string `json:"error,omitempty"`
+}

--- a/internal/providers/service.go
+++ b/internal/providers/service.go
@@ -26,21 +26,33 @@ func NewService(symbolService *models.SymbolService, settingService *models.Sett
 
 // getProvider returns the configured provider with API key
 func (s *Service) getProvider() (Provider, error) {
-	apiKey := s.settingService.GetValue("POLYGON_API_KEY")
-	if apiKey == "" {
-		return nil, fmt.Errorf("Polygon API key not configured - please set your API key in Settings")
+	// Determine which data provider to use, defaulting to Polygon for backwards compatibility
+	providerType := s.settingService.GetValue("DATA_PROVIDER_TYPE")
+	if providerType == "" {
+		providerType = "polygon"
 	}
+	providerType = strings.ToLower(providerType)
 
-	// Log masked API key for debugging
-	var maskedKey string
-	if len(apiKey) > 6 {
-		maskedKey = apiKey[:3] + "..." + apiKey[len(apiKey)-3:]
-	} else {
-		maskedKey = "***"
+	switch providerType {
+	case "polygon":
+		apiKey := s.settingService.GetValue("POLYGON_API_KEY")
+		if apiKey == "" {
+			return nil, fmt.Errorf("Polygon API key not configured - please set your API key in Settings")
+		}
+
+		// Log masked API key for debugging
+		var maskedKey string
+		if len(apiKey) > 6 {
+			maskedKey = apiKey[:3] + "..." + apiKey[len(apiKey)-3:]
+		} else {
+			maskedKey = "***"
+		}
+		log.Printf("[PROVIDER] Using %s provider with API key: %s", strings.ToUpper(providerType), maskedKey)
+
+		return NewPolygonProvider(apiKey), nil
+	default:
+		return nil, fmt.Errorf("unsupported data provider type: %s", providerType)
 	}
-	log.Printf("[PROVIDER] Using API key: %s", maskedKey)
-
-	return NewPolygonProvider(apiKey), nil
 }
 
 // UpdateSymbolPrice updates a single symbol's price from the configured provider
@@ -103,7 +115,7 @@ func (s *Service) UpdateAllSymbolPrices(ctx context.Context) error {
 			updated++
 		}
 
-		// Rate limiting: Free tier allows 5 requests per minute
+		// Rate limiting: Polygon.io Free tier allows 5 requests per minute (approx. 1 request every 12 seconds)
 		time.Sleep(12 * time.Second)
 	}
 

--- a/internal/providers/service.go
+++ b/internal/providers/service.go
@@ -261,7 +261,7 @@ func (s *Service) GetAPIKeyStatus() *APIKeyStatus {
 	return status
 }
 
-// getRateLimitDelay returns the rate limit delay based on the configured provider
+// GetRateLimitDelay returns the rate limit delay based on the configured provider
 func (s *Service) GetRateLimitDelay() time.Duration {
 	providerType := strings.ToLower(strings.TrimSpace(s.settingService.GetValue("DATA_PROVIDER_TYPE")))
 	if providerType == "" {

--- a/internal/providers/service.go
+++ b/internal/providers/service.go
@@ -16,6 +16,26 @@ type Service struct {
 	settingService *models.SettingService
 }
 
+// BulkPriceUpdateResult captures aggregate information from a bulk price update run
+type BulkPriceUpdateResult struct {
+	Updated int
+	Failed  int
+	Errors  []string
+}
+
+// DividendFetchRecord captures dividend data returned for a symbol
+type DividendFetchRecord struct {
+	Symbol    string
+	Dividends []*DividendInfo
+}
+
+// BulkDividendFetchResult summarizes dividend history fetches across many symbols
+type BulkDividendFetchResult struct {
+	Processed int
+	Results   []DividendFetchRecord
+	Errors    []string
+}
+
 // NewService creates a new provider service with the default provider
 func NewService(symbolService *models.SymbolService, settingService *models.SettingService) *Service {
 	return &Service{
@@ -100,45 +120,36 @@ func (s *Service) updateSymbolPriceWithProvider(ctx context.Context, provider Pr
 }
 
 // UpdateAllSymbolPrices updates prices for all symbols in the database
-func (s *Service) UpdateAllSymbolPrices(ctx context.Context) error {
+func (s *Service) UpdateAllSymbolPrices(ctx context.Context) (*BulkPriceUpdateResult, error) {
 	symbols, err := s.symbolService.GetPrioritizedSymbols()
 	if err != nil {
-		return fmt.Errorf("failed to get prioritized symbols: %w", err)
+		return nil, fmt.Errorf("failed to get prioritized symbols: %w", err)
+	}
+
+	log.Printf("[PROVIDER] Starting prioritized bulk price update for %d symbols", len(symbols))
+	return s.UpdateSymbolPrices(ctx, symbols)
+}
+
+// UpdateSymbolPrices updates prices for the provided symbol list using a shared provider instance
+func (s *Service) UpdateSymbolPrices(ctx context.Context, symbols []string) (*BulkPriceUpdateResult, error) {
+	normalized := s.normalizeSymbols(symbols)
+	if len(normalized) == 0 {
+		return &BulkPriceUpdateResult{}, nil
 	}
 
 	provider, err := s.getProvider()
 	if err != nil {
-		return err
+		return nil, fmt.Errorf("failed to get provider: %w", err)
 	}
 
-	log.Printf("[PROVIDER] Starting prioritized bulk price update for %d symbols using %s", len(symbols), provider.Name())
-
-	// Get rate limit configuration from provider (or use default)
-	rateLimitDelay := s.GetRateLimitDelay()
-
-	var updated, failed int
-	for _, symbol := range symbols {
-		if err := s.updateSymbolPriceWithProvider(ctx, provider, symbol); err != nil {
-			log.Printf("[PROVIDER] Failed to update %s: %v", symbol, err)
-			failed++
-		} else {
-			updated++
-		}
-
-		// Rate limiting to respect provider API limits, while honoring context cancellation
-		if rateLimitDelay > 0 {
-			select {
-			case <-ctx.Done():
-				log.Printf("[PROVIDER] Prioritized bulk price update canceled during rate limiting: %v", ctx.Err())
-				return ctx.Err()
-			case <-time.After(rateLimitDelay):
-				// continue to next symbol
-			}
-		}
+	log.Printf("[PROVIDER] Starting price update for %d symbols using %s", len(normalized), provider.Name())
+	result, runErr := s.runPriceUpdates(ctx, provider, normalized)
+	if runErr != nil {
+		return result, runErr
 	}
 
-	log.Printf("[PROVIDER] Prioritized bulk price update complete: %d updated, %d failed", updated, failed)
-	return nil
+	log.Printf("[PROVIDER] Price update complete: %d updated, %d failed", result.Updated, result.Failed)
+	return result, nil
 }
 
 // FetchSymbolDetails gets detailed information about a symbol from the provider
@@ -199,21 +210,50 @@ func (s *Service) FetchDividendHistory(ctx context.Context, symbol string, limit
 		return nil, fmt.Errorf("failed to get dividends: %w", err)
 	}
 
-	var result []*DividendInfo
-	for _, div := range dividends {
-		info := &DividendInfo{
-			Symbol:          div.Symbol,
-			CashAmount:      div.CashAmount,
-			DeclarationDate: div.DeclarationDate,
-			ExDividendDate:  div.ExDividendDate,
-			PayDate:         div.PayDate,
-			RecordDate:      div.RecordDate,
-			DividendType:    div.DividendType,
-			Frequency:       div.Frequency,
-		}
-		result = append(result, info)
+	return convertDividendsToInfo(dividends), nil
+}
+
+// FetchDividendHistoryForSymbols fetches dividend history for each provided symbol
+func (s *Service) FetchDividendHistoryForSymbols(ctx context.Context, symbols []string, limit int) (*BulkDividendFetchResult, error) {
+	normalized := s.normalizeSymbols(symbols)
+	if len(normalized) == 0 {
+		return &BulkDividendFetchResult{Results: []DividendFetchRecord{}}, nil
 	}
 
+	if limit <= 0 {
+		limit = 10
+	}
+
+	provider, err := s.getProvider()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get provider: %w", err)
+	}
+
+	log.Printf("[PROVIDER] Starting dividend fetch for %d symbols using %s", len(normalized), provider.Name())
+	rateLimitDelay := s.GetRateLimitDelay()
+	result := &BulkDividendFetchResult{}
+
+	for idx, symbol := range normalized {
+		result.Processed++
+		dividends, fetchErr := provider.GetDividends(ctx, symbol, limit)
+		if fetchErr != nil {
+			log.Printf("[PROVIDER] Failed to fetch dividends for %s: %v", symbol, fetchErr)
+			result.Errors = append(result.Errors, fmt.Sprintf("%s: %v", symbol, fetchErr))
+		} else {
+			result.Results = append(result.Results, DividendFetchRecord{
+				Symbol:    symbol,
+				Dividends: convertDividendsToInfo(dividends),
+			})
+		}
+
+		if idx < len(normalized)-1 {
+			if err := s.waitForRateLimit(ctx, rateLimitDelay); err != nil {
+				return result, err
+			}
+		}
+	}
+
+	log.Printf("[PROVIDER] Dividend fetch complete: %d symbols processed", result.Processed)
 	return result, nil
 }
 
@@ -333,4 +373,76 @@ type APIKeyStatus struct {
 	Masked     string `json:"masked"`
 	Valid      bool   `json:"valid"`
 	Error      string `json:"error,omitempty"`
+}
+
+func (s *Service) runPriceUpdates(ctx context.Context, provider Provider, symbols []string) (*BulkPriceUpdateResult, error) {
+	rateLimitDelay := s.GetRateLimitDelay()
+	result := &BulkPriceUpdateResult{}
+
+	for idx, symbol := range symbols {
+		if err := s.updateSymbolPriceWithProvider(ctx, provider, symbol); err != nil {
+			result.Failed++
+			result.Errors = append(result.Errors, fmt.Sprintf("%s: %v", symbol, err))
+			log.Printf("[PROVIDER] Failed to update %s: %v", symbol, err)
+		} else {
+			result.Updated++
+		}
+
+		if idx < len(symbols)-1 {
+			if err := s.waitForRateLimit(ctx, rateLimitDelay); err != nil {
+				return result, err
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func (s *Service) waitForRateLimit(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return nil
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(delay):
+		return nil
+	}
+}
+
+func (s *Service) normalizeSymbols(symbols []string) []string {
+	seen := make(map[string]struct{})
+	var normalized []string
+
+	for _, raw := range symbols {
+		symbol := strings.ToUpper(strings.TrimSpace(raw))
+		if symbol == "" {
+			continue
+		}
+		if _, exists := seen[symbol]; exists {
+			continue
+		}
+		seen[symbol] = struct{}{}
+		normalized = append(normalized, symbol)
+	}
+
+	return normalized
+}
+
+func convertDividendsToInfo(dividends []*Dividend) []*DividendInfo {
+	result := make([]*DividendInfo, 0, len(dividends))
+	for _, div := range dividends {
+		result = append(result, &DividendInfo{
+			Symbol:          div.Symbol,
+			CashAmount:      div.CashAmount,
+			DeclarationDate: div.DeclarationDate,
+			ExDividendDate:  div.ExDividendDate,
+			PayDate:         div.PayDate,
+			RecordDate:      div.RecordDate,
+			DividendType:    div.DividendType,
+			Frequency:       div.Frequency,
+		})
+	}
+	return result
 }

--- a/internal/providers/service.go
+++ b/internal/providers/service.go
@@ -261,6 +261,21 @@ func (s *Service) GetAPIKeyStatus() *APIKeyStatus {
 	return status
 }
 
+// Name returns the name of the configured provider
+func (s *Service) Name() string {
+	providerType := strings.ToLower(strings.TrimSpace(s.settingService.GetValue("DATA_PROVIDER_TYPE")))
+	if providerType == "" {
+		providerType = "polygon"
+	}
+
+	switch providerType {
+	case "polygon":
+		return "Polygon.io"
+	default:
+		return strings.Title(providerType)
+	}
+}
+
 // GetRateLimitDelay returns the rate limit delay based on the configured provider
 func (s *Service) GetRateLimitDelay() time.Duration {
 	providerType := strings.ToLower(strings.TrimSpace(s.settingService.GetValue("DATA_PROVIDER_TYPE")))

--- a/internal/web/polygon_handlers.go
+++ b/internal/web/polygon_handlers.go
@@ -23,7 +23,7 @@ func (s *Server) polygonTestHandler(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 
 	// Test the connection
-	err := s.polygonService.TestConnection(ctx)
+	err := s.providerService.TestConnection(ctx)
 	
 	response := map[string]interface{}{
 		"success": err == nil,
@@ -81,7 +81,7 @@ func (s *Server) polygonUpdatePricesHandler(w http.ResponseWriter, r *http.Reque
 		log.Printf("[POLYGON API] Updating prices for %d symbols (prioritized order)", len(symbols))
 
 		for _, symbol := range symbols {
-			if err := s.polygonService.UpdateSymbolPrice(ctx, symbol); err != nil {
+			if err := s.providerService.UpdateSymbolPrice(ctx, symbol); err != nil {
 				log.Printf("[POLYGON API] Failed to update %s: %v", symbol, err)
 				errors = append(errors, symbol+": "+err.Error())
 				failed++
@@ -97,7 +97,7 @@ func (s *Server) polygonUpdatePricesHandler(w http.ResponseWriter, r *http.Reque
 		log.Printf("[POLYGON API] Updating prices for specific symbols: %v", request.Symbols)
 
 		for _, symbol := range request.Symbols {
-			if err := s.polygonService.UpdateSymbolPrice(ctx, symbol); err != nil {
+			if err := s.providerService.UpdateSymbolPrice(ctx, symbol); err != nil {
 				log.Printf("[POLYGON API] Failed to update %s: %v", symbol, err)
 				errors = append(errors, symbol+": "+err.Error())
 				failed++
@@ -157,7 +157,7 @@ func (s *Server) polygonSymbolInfoHandler(w http.ResponseWriter, r *http.Request
 	defer cancel()
 
 	// Get symbol info from Polygon
-	info, err := s.polygonService.FetchSymbolDetails(ctx, symbol)
+	info, err := s.providerService.FetchSymbolDetails(ctx, symbol)
 	if err != nil {
 		log.Printf("[POLYGON API] Error getting symbol info for %s: %v", symbol, err)
 		response := map[string]interface{}{
@@ -171,7 +171,7 @@ func (s *Server) polygonSymbolInfoHandler(w http.ResponseWriter, r *http.Request
 	}
 
 	// Get dividend history (optional)
-	dividends, err := s.polygonService.FetchDividendHistory(ctx, symbol, 5)
+	dividends, err := s.providerService.FetchDividendHistory(ctx, symbol, 5)
 	if err != nil {
 		log.Printf("[POLYGON API] Warning: failed to get dividend history for %s: %v", symbol, err)
 		// Continue without dividends
@@ -201,14 +201,14 @@ func (s *Server) polygonStatusHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	status := s.polygonService.GetAPIKeyStatus()
+	status := s.providerService.GetAPIKeyStatus()
 
 	// Test connection if API key is configured
 	if status.Configured {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
-		if err := s.polygonService.TestConnection(ctx); err != nil {
+		if err := s.providerService.TestConnection(ctx); err != nil {
 			status.Valid = false
 			status.Error = err.Error()
 		} else {
@@ -266,7 +266,7 @@ func (s *Server) polygonFetchDividendsHandler(w http.ResponseWriter, r *http.Req
 		log.Printf("[POLYGON API] Fetching dividends for %d symbols (prioritized order)", len(symbols))
 
 		for _, symbol := range symbols {
-			dividends, err := s.polygonService.FetchDividendHistory(ctx, symbol, request.Limit)
+			dividends, err := s.providerService.FetchDividendHistory(ctx, symbol, request.Limit)
 			processed++
 			
 			if err != nil {
@@ -288,7 +288,7 @@ func (s *Server) polygonFetchDividendsHandler(w http.ResponseWriter, r *http.Req
 		log.Printf("[POLYGON API] Fetching dividends for specific symbols: %v", request.Symbols)
 
 		for _, symbol := range request.Symbols {
-			dividends, err := s.polygonService.FetchDividendHistory(ctx, symbol, request.Limit)
+			dividends, err := s.providerService.FetchDividendHistory(ctx, symbol, request.Limit)
 			processed++
 			
 			if err != nil {

--- a/internal/web/polygon_handlers.go
+++ b/internal/web/polygon_handlers.go
@@ -91,8 +91,8 @@ func (s *Server) polygonUpdatePricesHandler(w http.ResponseWriter, r *http.Reque
 				updated++
 			}
 
-			// Rate limiting for free tier (5 requests per minute)
-			time.Sleep(12 * time.Second)
+			// Rate limiting based on provider configuration
+			time.Sleep(s.providerService.GetRateLimitDelay())
 		}
 	} else {
 		// Update specific symbols
@@ -107,9 +107,9 @@ func (s *Server) polygonUpdatePricesHandler(w http.ResponseWriter, r *http.Reque
 				updated++
 			}
 
-			// Rate limiting
+			// Rate limiting based on provider configuration
 			if len(request.Symbols) > 1 {
-				time.Sleep(12 * time.Second)
+				time.Sleep(s.providerService.GetRateLimitDelay())
 			}
 		}
 	}
@@ -158,7 +158,7 @@ func (s *Server) polygonSymbolInfoHandler(w http.ResponseWriter, r *http.Request
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Get symbol info from Polygon
+	// Get symbol info from configured data provider
 	info, err := s.providerService.FetchSymbolDetails(ctx, symbol)
 	if err != nil {
 		log.Printf("[POLYGON API] Error getting symbol info for %s: %v", symbol, err)
@@ -282,8 +282,8 @@ func (s *Server) polygonFetchDividendsHandler(w http.ResponseWriter, r *http.Req
 				})
 			}
 
-			// Rate limiting for free tier (5 requests per minute)
-			time.Sleep(12 * time.Second)
+			// Rate limiting based on provider configuration
+			time.Sleep(s.providerService.GetRateLimitDelay())
 		}
 	} else {
 		// Fetch dividends for specific symbols
@@ -304,9 +304,9 @@ func (s *Server) polygonFetchDividendsHandler(w http.ResponseWriter, r *http.Req
 				})
 			}
 
-			// Rate limiting
+			// Rate limiting based on provider configuration
 			if len(request.Symbols) > 1 {
-				time.Sleep(12 * time.Second)
+				time.Sleep(s.providerService.GetRateLimitDelay())
 			}
 		}
 	}

--- a/internal/web/polygon_handlers.go
+++ b/internal/web/polygon_handlers.go
@@ -20,11 +20,52 @@ func (s *Server) polygonTestHandler(w http.ResponseWriter, r *http.Request) {
 	log.Printf("[POLYGON API] Testing API connection")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	package web
 
-	// Test the connection
-	err := s.providerService.TestConnection(ctx)
-	
+	import (
+		"context"
+		"encoding/json"
+		"fmt"
+		"log"
+		"net/http"
+		"strings"
+		"time"
+	)
+
+	// polygonTestHandler tests the data provider API connection
+	func (s *Server) polygonTestHandler(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		providerName := s.providerService.Name()
+		logPrefix := fmt.Sprintf("[%s API]", strings.ToUpper(providerName))
+		log.Printf("%s Testing API connection", logPrefix)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		err := s.providerService.TestConnection(ctx)
+		
+		response := map[string]interface{}{
+			"success":  err == nil,
+			"provider": providerName,
+		}
+
+		if err != nil {
+			response["error"] = err.Error()
+			log.Printf("%s Connection test failed: %v", logPrefix, err)
+		} else {
+			response["message"] = "API key is valid and connection successful"
+			log.Printf("%s Connection test successful", logPrefix)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			log.Printf("%s Error encoding test response: %v", logPrefix, err)
+		}
+	}
 	response := map[string]interface{}{
 		"success": err == nil,
 	}

--- a/internal/web/polygon_handlers.go
+++ b/internal/web/polygon_handlers.go
@@ -10,77 +10,38 @@ import (
 	"time"
 )
 
-// polygonTestHandler tests the Polygon API connection
+// polygonTestHandler tests the data provider API connection
 func (s *Server) polygonTestHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
-	log.Printf("[POLYGON API] Testing API connection")
+	providerName := s.providerService.Name()
+	logPrefix := fmt.Sprintf("[%s API]", strings.ToUpper(providerName))
+	log.Printf("%s Testing API connection", logPrefix)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	package web
+	defer cancel()
 
-	import (
-		"context"
-		"encoding/json"
-		"fmt"
-		"log"
-		"net/http"
-		"strings"
-		"time"
-	)
+	err := s.providerService.TestConnection(ctx)
 
-	// polygonTestHandler tests the data provider API connection
-	func (s *Server) polygonTestHandler(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-
-		providerName := s.providerService.Name()
-		logPrefix := fmt.Sprintf("[%s API]", strings.ToUpper(providerName))
-		log.Printf("%s Testing API connection", logPrefix)
-
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-
-		err := s.providerService.TestConnection(ctx)
-		
-		response := map[string]interface{}{
-			"success":  err == nil,
-			"provider": providerName,
-		}
-
-		if err != nil {
-			response["error"] = err.Error()
-			log.Printf("%s Connection test failed: %v", logPrefix, err)
-		} else {
-			response["message"] = "API key is valid and connection successful"
-			log.Printf("%s Connection test successful", logPrefix)
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(response); err != nil {
-			log.Printf("%s Error encoding test response: %v", logPrefix, err)
-		}
-	}
 	response := map[string]interface{}{
-		"success": err == nil,
+		"success":  err == nil,
+		"provider": providerName,
 	}
 
 	if err != nil {
 		response["error"] = err.Error()
-		log.Printf("[POLYGON API] Connection test failed: %v", err)
+		log.Printf("%s Connection test failed: %v", logPrefix, err)
 	} else {
 		response["message"] = "API key is valid and connection successful"
-		log.Printf("[POLYGON API] Connection test successful")
+		log.Printf("%s Connection test successful", logPrefix)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(response); err != nil {
-		log.Printf("[POLYGON API] Error encoding test response: %v", err)
+		log.Printf("%s Error encoding test response: %v", logPrefix, err)
 	}
 }
 
@@ -235,7 +196,7 @@ func (s *Server) polygonSymbolInfoHandler(w http.ResponseWriter, r *http.Request
 	}
 }
 
-// polygonStatusHandler returns the status of the Polygon integration  
+// polygonStatusHandler returns the status of the Polygon integration
 func (s *Server) polygonStatusHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -309,7 +270,7 @@ func (s *Server) polygonFetchDividendsHandler(w http.ResponseWriter, r *http.Req
 		for _, symbol := range symbols {
 			dividends, err := s.providerService.FetchDividendHistory(ctx, symbol, request.Limit)
 			processed++
-			
+
 			if err != nil {
 				log.Printf("[POLYGON API] Failed to fetch dividends for %s: %v", symbol, err)
 				errors = append(errors, symbol+": "+err.Error())
@@ -331,7 +292,7 @@ func (s *Server) polygonFetchDividendsHandler(w http.ResponseWriter, r *http.Req
 		for _, symbol := range request.Symbols {
 			dividends, err := s.providerService.FetchDividendHistory(ctx, symbol, request.Limit)
 			processed++
-			
+
 			if err != nil {
 				log.Printf("[POLYGON API] Failed to fetch dividends for %s: %v", symbol, err)
 				errors = append(errors, symbol+": "+err.Error())
@@ -366,7 +327,7 @@ func (s *Server) polygonFetchDividendsHandler(w http.ResponseWriter, r *http.Req
 			totalDividends += count
 		}
 	}
-	
+
 	response["message"] = fmt.Sprintf("Dividend fetch completed: %d symbols processed, %d total dividends found", processed, totalDividends)
 
 	log.Printf("[POLYGON API] Dividend fetch completed: %d symbols processed, %d total dividends found", processed, totalDividends)

--- a/internal/web/polygon_handlers.go
+++ b/internal/web/polygon_handlers.go
@@ -8,17 +8,27 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"stonks/internal/providers"
 )
 
-// polygonTestHandler tests the data provider API connection
-func (s *Server) polygonTestHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) providerLogPrefix() string {
+	name := strings.ToUpper(strings.TrimSpace(s.providerService.Name()))
+	if name == "" {
+		name = "PROVIDER"
+	}
+	return fmt.Sprintf("[%s API]", name)
+}
+
+// providerTestHandler tests the data provider API connection
+func (s *Server) providerTestHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
 	providerName := s.providerService.Name()
-	logPrefix := fmt.Sprintf("[%s API]", strings.ToUpper(providerName))
+	logPrefix := s.providerLogPrefix()
 	log.Printf("%s Testing API connection", logPrefix)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -45,14 +55,15 @@ func (s *Server) polygonTestHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// polygonUpdatePricesHandler triggers price updates for symbols
-func (s *Server) polygonUpdatePricesHandler(w http.ResponseWriter, r *http.Request) {
+// providerUpdatePricesHandler triggers price updates for symbols
+func (s *Server) providerUpdatePricesHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
-	log.Printf("[POLYGON API] Starting price update request")
+	logPrefix := s.providerLogPrefix()
+	log.Printf("%s Starting price update request", logPrefix)
 
 	// Parse request body to get specific symbols (optional)
 	var request struct {
@@ -68,92 +79,66 @@ func (s *Server) polygonUpdatePricesHandler(w http.ResponseWriter, r *http.Reque
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	var updated, failed int
-	var errors []string
+	var (
+		result *providers.BulkPriceUpdateResult
+		err    error
+	)
 
 	if request.All || len(request.Symbols) == 0 {
-		// Update all symbols (prioritized: active positions first)
-		symbols, err := s.symbolService.GetPrioritizedSymbols()
-		if err != nil {
-			log.Printf("[POLYGON API] Error getting prioritized symbols: %v", err)
-			http.Error(w, "Failed to get symbols", http.StatusInternalServerError)
-			return
-		}
-
-		log.Printf("[POLYGON API] Updating prices for %d symbols (prioritized order)", len(symbols))
-
-		for _, symbol := range symbols {
-			if err := s.providerService.UpdateSymbolPrice(ctx, symbol); err != nil {
-				log.Printf("[POLYGON API] Failed to update %s: %v", symbol, err)
-				errors = append(errors, symbol+": "+err.Error())
-				failed++
-			} else {
-				updated++
-			}
-
-			// Rate limiting based on provider configuration
-			time.Sleep(s.providerService.GetRateLimitDelay())
-		}
+		result, err = s.providerService.UpdateAllSymbolPrices(ctx)
 	} else {
-		// Update specific symbols
-		log.Printf("[POLYGON API] Updating prices for specific symbols: %v", request.Symbols)
-
-		for _, symbol := range request.Symbols {
-			if err := s.providerService.UpdateSymbolPrice(ctx, symbol); err != nil {
-				log.Printf("[POLYGON API] Failed to update %s: %v", symbol, err)
-				errors = append(errors, symbol+": "+err.Error())
-				failed++
-			} else {
-				updated++
-			}
-
-			// Rate limiting based on provider configuration
-			if len(request.Symbols) > 1 {
-				time.Sleep(s.providerService.GetRateLimitDelay())
-			}
-		}
+		result, err = s.providerService.UpdateSymbolPrices(ctx, request.Symbols)
 	}
 
+	if result == nil {
+		result = &providers.BulkPriceUpdateResult{}
+	}
+
+	success := err == nil && result.Updated > 0
 	response := map[string]interface{}{
-		"success": updated > 0,
-		"updated": updated,
-		"failed":  failed,
+		"success": success,
+		"updated": result.Updated,
+		"failed":  result.Failed,
 	}
 
-	if len(errors) > 0 {
-		response["errors"] = errors
+	if len(result.Errors) > 0 {
+		response["errors"] = result.Errors
 	}
 
-	if updated > 0 {
+	if err != nil {
+		response["message"] = err.Error()
+		log.Printf("%s Price update failed: %v", logPrefix, err)
+	} else if success {
 		response["message"] = "Price update completed"
+		log.Printf("%s Price update completed: %d updated, %d failed", logPrefix, result.Updated, result.Failed)
 	} else {
 		response["message"] = "No prices were updated"
+		log.Printf("%s Price update completed with no updates", logPrefix)
 	}
-
-	log.Printf("[POLYGON API] Price update completed: %d updated, %d failed", updated, failed)
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(response); err != nil {
-		log.Printf("[POLYGON API] Error encoding update response: %v", err)
+		log.Printf("%s Error encoding update response: %v", logPrefix, err)
 	}
 }
 
-// polygonSymbolInfoHandler gets detailed symbol information from Polygon
-func (s *Server) polygonSymbolInfoHandler(w http.ResponseWriter, r *http.Request) {
+// providerSymbolInfoHandler gets detailed symbol information from the configured provider
+func (s *Server) providerSymbolInfoHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
 	// Extract symbol from URL path
-	path := strings.TrimPrefix(r.URL.Path, "/api/polygon/symbol-info/")
+	path := strings.TrimPrefix(r.URL.Path, "/api/provider/symbol-info/")
 	if path == "" {
 		http.Error(w, "Symbol required", http.StatusBadRequest)
 		return
 	}
 
 	symbol := strings.ToUpper(path)
-	log.Printf("[POLYGON API] Getting symbol info for: %s", symbol)
+	logPrefix := s.providerLogPrefix()
+	log.Printf("%s Getting symbol info for: %s", logPrefix, symbol)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -161,7 +146,7 @@ func (s *Server) polygonSymbolInfoHandler(w http.ResponseWriter, r *http.Request
 	// Get symbol info from configured data provider
 	info, err := s.providerService.FetchSymbolDetails(ctx, symbol)
 	if err != nil {
-		log.Printf("[POLYGON API] Error getting symbol info for %s: %v", symbol, err)
+		log.Printf("%s Error getting symbol info for %s: %v", logPrefix, symbol, err)
 		response := map[string]interface{}{
 			"success": false,
 			"error":   err.Error(),
@@ -175,7 +160,7 @@ func (s *Server) polygonSymbolInfoHandler(w http.ResponseWriter, r *http.Request
 	// Get dividend history (optional)
 	dividends, err := s.providerService.FetchDividendHistory(ctx, symbol, 5)
 	if err != nil {
-		log.Printf("[POLYGON API] Warning: failed to get dividend history for %s: %v", symbol, err)
+		log.Printf("%s Warning: failed to get dividend history for %s: %v", logPrefix, symbol, err)
 		// Continue without dividends
 	}
 
@@ -188,22 +173,23 @@ func (s *Server) polygonSymbolInfoHandler(w http.ResponseWriter, r *http.Request
 		response["dividends"] = dividends
 	}
 
-	log.Printf("[POLYGON API] Successfully retrieved info for %s", symbol)
+	log.Printf("%s Successfully retrieved info for %s", logPrefix, symbol)
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(response); err != nil {
-		log.Printf("[POLYGON API] Error encoding symbol info response: %v", err)
+		log.Printf("%s Error encoding symbol info response: %v", logPrefix, err)
 	}
 }
 
-// polygonStatusHandler returns the status of the Polygon integration
-func (s *Server) polygonStatusHandler(w http.ResponseWriter, r *http.Request) {
+// providerStatusHandler returns the status of the provider integration
+func (s *Server) providerStatusHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
 	status := s.providerService.GetAPIKeyStatus()
+	logPrefix := s.providerLogPrefix()
 
 	// Test connection if API key is configured
 	if status.Configured {
@@ -220,18 +206,19 @@ func (s *Server) polygonStatusHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(status); err != nil {
-		log.Printf("[POLYGON API] Error encoding status response: %v", err)
+		log.Printf("%s Error encoding status response: %v", logPrefix, err)
 	}
 }
 
-// polygonFetchDividendsHandler fetches dividend data for all symbols
-func (s *Server) polygonFetchDividendsHandler(w http.ResponseWriter, r *http.Request) {
+// providerFetchDividendsHandler fetches dividend data for symbols
+func (s *Server) providerFetchDividendsHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
-	log.Printf("[POLYGON API] Starting bulk dividend fetch request")
+	logPrefix := s.providerLogPrefix()
+	log.Printf("%s Starting bulk dividend fetch request", logPrefix)
 
 	// Parse request body to get specific symbols (optional)
 	var request struct {
@@ -252,88 +239,49 @@ func (s *Server) polygonFetchDividendsHandler(w http.ResponseWriter, r *http.Req
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	var processed int
-	var results []map[string]interface{}
-	var errors []string
-
+	var symbols []string
 	if request.All || len(request.Symbols) == 0 {
-		// Fetch dividends for all symbols (prioritized: active positions first)
-		symbols, err := s.symbolService.GetPrioritizedSymbols()
+		var err error
+		symbols, err = s.symbolService.GetPrioritizedSymbols()
 		if err != nil {
-			log.Printf("[POLYGON API] Error getting prioritized symbols: %v", err)
+			log.Printf("%s Error getting prioritized symbols: %v", logPrefix, err)
 			http.Error(w, "Failed to get symbols", http.StatusInternalServerError)
 			return
 		}
-
-		log.Printf("[POLYGON API] Fetching dividends for %d symbols (prioritized order)", len(symbols))
-
-		for _, symbol := range symbols {
-			dividends, err := s.providerService.FetchDividendHistory(ctx, symbol, request.Limit)
-			processed++
-
-			if err != nil {
-				log.Printf("[POLYGON API] Failed to fetch dividends for %s: %v", symbol, err)
-				errors = append(errors, symbol+": "+err.Error())
-			} else {
-				results = append(results, map[string]interface{}{
-					"symbol":    symbol,
-					"dividends": dividends,
-					"count":     len(dividends),
-				})
-			}
-
-			// Rate limiting based on provider configuration
-			time.Sleep(s.providerService.GetRateLimitDelay())
-		}
 	} else {
-		// Fetch dividends for specific symbols
-		log.Printf("[POLYGON API] Fetching dividends for specific symbols: %v", request.Symbols)
+		symbols = request.Symbols
+	}
 
-		for _, symbol := range request.Symbols {
-			dividends, err := s.providerService.FetchDividendHistory(ctx, symbol, request.Limit)
-			processed++
-
-			if err != nil {
-				log.Printf("[POLYGON API] Failed to fetch dividends for %s: %v", symbol, err)
-				errors = append(errors, symbol+": "+err.Error())
-			} else {
-				results = append(results, map[string]interface{}{
-					"symbol":    symbol,
-					"dividends": dividends,
-					"count":     len(dividends),
-				})
-			}
-
-			// Rate limiting based on provider configuration
-			if len(request.Symbols) > 1 {
-				time.Sleep(s.providerService.GetRateLimitDelay())
-			}
-		}
+	result, err := s.providerService.FetchDividendHistoryForSymbols(ctx, symbols, request.Limit)
+	if result == nil {
+		result = &providers.BulkDividendFetchResult{}
 	}
 
 	response := map[string]interface{}{
-		"success":   true,
-		"processed": processed,
-		"results":   results,
+		"success":   err == nil,
+		"processed": result.Processed,
+		"results":   result.Results,
 	}
 
-	if len(errors) > 0 {
-		response["errors"] = errors
+	if len(result.Errors) > 0 {
+		response["errors"] = result.Errors
 	}
 
 	totalDividends := 0
-	for _, result := range results {
-		if count, ok := result["count"].(int); ok {
-			totalDividends += count
-		}
+	for _, record := range result.Results {
+		totalDividends += len(record.Dividends)
 	}
 
-	response["message"] = fmt.Sprintf("Dividend fetch completed: %d symbols processed, %d total dividends found", processed, totalDividends)
-
-	log.Printf("[POLYGON API] Dividend fetch completed: %d symbols processed, %d total dividends found", processed, totalDividends)
+	if err != nil {
+		response["message"] = err.Error()
+		log.Printf("%s Dividend fetch failed: %v", logPrefix, err)
+	} else {
+		response["message"] = fmt.Sprintf("Dividend fetch completed: %d symbols processed, %d total dividends found", result.Processed, totalDividends)
+		log.Printf("%s Dividend fetch completed: %d symbols processed, %d total dividends found", logPrefix, result.Processed, totalDividends)
+	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(response); err != nil {
-		log.Printf("[POLYGON API] Error encoding dividend fetch response: %v", err)
+		log.Printf("%s Error encoding dividend fetch response: %v", logPrefix, err)
 	}
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -9,10 +9,10 @@ import (
 	"net/http"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"stonks/internal/database"
 	"stonks/internal/models"
 	"stonks/internal/providers"
+	"strconv"
 	"strings"
 	"time"
 
@@ -51,7 +51,7 @@ func NewServer() (*Server, error) {
 	// Load templates with custom functions
 	templatePath := filepath.Join("internal", "web", "templates", "*.html")
 	log.Printf("[SERVER] Loading HTML templates from: %s", templatePath)
-	
+
 	// Create template with custom functions
 	funcMap := template.FuncMap{
 		"groupByExpiration": groupPositionsByExpiration,
@@ -119,19 +119,19 @@ func NewServer() (*Server, error) {
 			default:
 				return "$0"
 			}
-			
+
 			// Round to nearest whole number
 			rounded := int64(floatVal + 0.5)
 			if floatVal < 0 {
 				rounded = int64(floatVal - 0.5)
 			}
-			
+
 			// Format with commas
 			str := fmt.Sprintf("%d", rounded)
 			if rounded < 0 {
 				str = str[1:] // Remove negative sign temporarily
 			}
-			
+
 			// Add commas
 			if len(str) > 3 {
 				var result string
@@ -143,7 +143,7 @@ func NewServer() (*Server, error) {
 				}
 				str = result
 			}
-			
+
 			if floatVal < 0 {
 				return "-$" + str
 			}
@@ -165,22 +165,22 @@ func NewServer() (*Server, error) {
 			default:
 				return "$0.00"
 			}
-			
+
 			// Format to 2 decimal places
 			formatted := fmt.Sprintf("%.2f", floatVal)
-			
+
 			// Split into integer and decimal parts
 			parts := strings.Split(formatted, ".")
 			intPart := parts[0]
 			decPart := parts[1]
-			
+
 			// Handle negative numbers
 			isNegative := false
 			if strings.HasPrefix(intPart, "-") {
 				isNegative = true
 				intPart = intPart[1:]
 			}
-			
+
 			// Add commas to integer part
 			if len(intPart) > 3 {
 				var result string
@@ -192,7 +192,7 @@ func NewServer() (*Server, error) {
 				}
 				intPart = result
 			}
-			
+
 			// Combine with decimals
 			formatted = intPart + "." + decPart
 			if isNegative {
@@ -210,14 +210,14 @@ func NewServer() (*Server, error) {
 			default:
 				return "0"
 			}
-			
+
 			str := fmt.Sprintf("%d", intVal)
 			isNegative := false
 			if intVal < 0 {
 				isNegative = true
 				str = str[1:]
 			}
-			
+
 			// Add commas
 			if len(str) > 3 {
 				var result string
@@ -229,14 +229,14 @@ func NewServer() (*Server, error) {
 				}
 				str = result
 			}
-			
+
 			if isNegative {
 				return "-" + str
 			}
 			return str
 		},
 	}
-	
+
 	templates, err := template.New("").Funcs(funcMap).ParseGlob(templatePath)
 	if err != nil {
 		log.Printf("[SERVER] ERROR: Failed to parse templates: %v", err)
@@ -245,11 +245,11 @@ func NewServer() (*Server, error) {
 	log.Printf("[SERVER] HTML templates loaded successfully")
 
 	log.Printf("[SERVER] Initializing service layers")
-	
+
 	// Initialize core services
 	symbolService := models.NewSymbolService(dbWrapper.DB)
 	settingService := models.NewSettingService(dbWrapper.DB)
-	
+
 	server := &Server{
 		db:                  dbWrapper.DB,
 		optionService:       models.NewOptionService(dbWrapper.DB),
@@ -426,20 +426,20 @@ func (s *Server) setupRoutes() {
 	http.HandleFunc("/api/settings/", s.individualSettingAPIHandler)
 	log.Printf("[SERVER] Route registered: /api/settings/ -> individualSettingAPIHandler")
 
-	http.HandleFunc("/api/polygon/test", s.polygonTestHandler)
-	log.Printf("[SERVER] Route registered: /api/polygon/test -> polygonTestHandler")
+	http.HandleFunc("/api/provider/test", s.providerTestHandler)
+	log.Printf("[SERVER] Route registered: /api/provider/test -> providerTestHandler")
 
-	http.HandleFunc("/api/polygon/update-prices", s.polygonUpdatePricesHandler)
-	log.Printf("[SERVER] Route registered: /api/polygon/update-prices -> polygonUpdatePricesHandler")
+	http.HandleFunc("/api/provider/update-prices", s.providerUpdatePricesHandler)
+	log.Printf("[SERVER] Route registered: /api/provider/update-prices -> providerUpdatePricesHandler")
 
-	http.HandleFunc("/api/polygon/symbol-info/", s.polygonSymbolInfoHandler)
-	log.Printf("[SERVER] Route registered: /api/polygon/symbol-info/ -> polygonSymbolInfoHandler")
+	http.HandleFunc("/api/provider/symbol-info/", s.providerSymbolInfoHandler)
+	log.Printf("[SERVER] Route registered: /api/provider/symbol-info/ -> providerSymbolInfoHandler")
 
-	http.HandleFunc("/api/polygon/status", s.polygonStatusHandler)
-	log.Printf("[SERVER] Route registered: /api/polygon/status -> polygonStatusHandler")
+	http.HandleFunc("/api/provider/status", s.providerStatusHandler)
+	log.Printf("[SERVER] Route registered: /api/provider/status -> providerStatusHandler")
 
-	http.HandleFunc("/api/polygon/fetch-dividends", s.polygonFetchDividendsHandler)
-	log.Printf("[SERVER] Route registered: /api/polygon/fetch-dividends -> polygonFetchDividendsHandler")
+	http.HandleFunc("/api/provider/fetch-dividends", s.providerFetchDividendsHandler)
+	log.Printf("[SERVER] Route registered: /api/provider/fetch-dividends -> providerFetchDividendsHandler")
 
 	log.Printf("[SERVER] All routes registered successfully")
 }
@@ -472,13 +472,13 @@ type ExpirationGroup struct {
 // groupPositionsByExpiration groups open positions by expiration date and returns them sorted
 func groupPositionsByExpiration(positions []*models.OpenPositionData) []ExpirationGroup {
 	grouped := make(map[time.Time][]*models.OpenPositionData)
-	
+
 	// Group positions by expiration date
 	for _, position := range positions {
 		expDate := position.Expiration
 		grouped[expDate] = append(grouped[expDate], position)
 	}
-	
+
 	// Convert to slice and sort by expiration date
 	var groups []ExpirationGroup
 	for expDate, posGroup := range grouped {
@@ -490,25 +490,25 @@ func groupPositionsByExpiration(positions []*models.OpenPositionData) []Expirati
 			}
 			return posI.Strike < posJ.Strike
 		})
-		
+
 		groups = append(groups, ExpirationGroup{
 			Expiration: expDate,
 			DateStr:    expDate.Format("01/02/2006"),
 			Positions:  posGroup,
 		})
 	}
-	
+
 	// Sort groups by expiration date (earliest first)
 	sort.Slice(groups, func(i, j int) bool {
 		return groups[i].Expiration.Before(groups[j].Expiration)
 	})
-	
+
 	return groups
 }
 
 func (s *Server) renderTemplate(w http.ResponseWriter, templateName string, data interface{}) {
 	log.Printf("[TEMPLATE] Starting template execution for: %s", templateName)
-	
+
 	// Use a buffer to execute template first, then write to response if successful
 	var buf bytes.Buffer
 	err := s.templates.ExecuteTemplate(&buf, templateName, data)
@@ -517,7 +517,7 @@ func (s *Server) renderTemplate(w http.ResponseWriter, templateName string, data
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
-	
+
 	// Template executed successfully, write to response
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	_, err = w.Write(buf.Bytes())

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -12,7 +12,7 @@ import (
 	"strconv"
 	"stonks/internal/database"
 	"stonks/internal/models"
-	"stonks/internal/polygon"
+	"stonks/internal/providers"
 	"strings"
 	"time"
 
@@ -28,7 +28,7 @@ type Server struct {
 	dividendService     *models.DividendService
 	settingService      *models.SettingService
 	metricService       *models.MetricService
-	polygonService      *polygon.Service
+	providerService     *providers.Service
 	templates           *template.Template
 }
 
@@ -259,7 +259,7 @@ func NewServer() (*Server, error) {
 		dividendService:     models.NewDividendService(dbWrapper.DB),
 		settingService:      settingService,
 		metricService:       models.NewMetricService(dbWrapper.DB),
-		polygonService:      polygon.NewService(symbolService, settingService),
+		providerService:     providers.NewService(symbolService, settingService),
 		templates:           templates,
 	}
 

--- a/internal/web/settings_handlers.go
+++ b/internal/web/settings_handlers.go
@@ -5,17 +5,18 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"strings"
 	"stonks/internal/models"
+	"strings"
 )
 
 // SettingsData holds data for the settings template
 type SettingsData struct {
-	Settings   []*models.Setting `json:"settings"`
-	AllSymbols []string          `json:"allSymbols"`
-	CurrentDB  string            `json:"currentDB"`
-	ApiKey     string            `json:"apiKey"`
-	ActivePage string            `json:"activePage"`
+	Settings     []*models.Setting `json:"settings"`
+	AllSymbols   []string          `json:"allSymbols"`
+	CurrentDB    string            `json:"currentDB"`
+	ApiKey       string            `json:"apiKey"`
+	ProviderName string            `json:"providerName"`
+	ActivePage   string            `json:"activePage"`
 }
 
 // settingsHandler serves the settings management page
@@ -40,14 +41,31 @@ func (s *Server) settingsHandler(w http.ResponseWriter, r *http.Request) {
 	apiKey := s.settingService.GetValue("POLYGON_API_KEY")
 
 	data := SettingsData{
-		Settings:   settings,
-		AllSymbols: symbols,
-		CurrentDB:  s.getCurrentDatabaseName(),
-		ApiKey:     apiKey,
-		ActivePage: "settings",
+		Settings:     settings,
+		AllSymbols:   symbols,
+		CurrentDB:    s.getCurrentDatabaseName(),
+		ApiKey:       apiKey,
+		ProviderName: formatProviderDisplayName(s.providerService.Name()),
+		ActivePage:   "settings",
 	}
 
 	s.renderTemplate(w, "settings.html", data)
+}
+
+func formatProviderDisplayName(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "Market Data Provider"
+	}
+	lower := strings.ToLower(trimmed)
+	switch lower {
+	case "polygon":
+		return "Polygon.io"
+	default:
+		runes := []rune(trimmed)
+		runes[0] = []rune(strings.ToUpper(string(runes[0])))[0]
+		return string(runes)
+	}
 }
 
 // settingsAPIHandler handles CRUD operations for settings collection

--- a/internal/web/settings_handlers.go
+++ b/internal/web/settings_handlers.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"stonks/internal/models"
 	"strings"
+	"unicode"
 )
 
 // SettingsData holds data for the settings template
@@ -63,7 +64,7 @@ func formatProviderDisplayName(raw string) string {
 		return "Polygon.io"
 	default:
 		runes := []rune(trimmed)
-		runes[0] = []rune(strings.ToUpper(string(runes[0])))[0]
+		runes[0] = unicode.ToUpper(runes[0])
 		return string(runes)
 	}
 }

--- a/internal/web/symbol_handlers.go
+++ b/internal/web/symbol_handlers.go
@@ -1,8 +1,8 @@
 package web
 
 import (
-	"encoding/json"
 	"context"
+	"encoding/json"
 	"log"
 	"net/http"
 	"sort"
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 )
-
 
 // symbolHandler serves the symbol-specific analysis view
 func (s *Server) symbolHandler(w http.ResponseWriter, r *http.Request) {
@@ -483,9 +482,9 @@ func (s *Server) symbolUpdatePriceHandler(w http.ResponseWriter, r *http.Request
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Update symbol price using Polygon service
+	// Update symbol price using configured market data provider
 	err := s.providerService.UpdateSymbolPrice(ctx, symbol)
-	
+
 	response := map[string]interface{}{
 		"success": err == nil,
 		"symbol":  symbol,
@@ -520,7 +519,7 @@ func (s *Server) symbolFetchDividendsHandler(w http.ResponseWriter, r *http.Requ
 
 	// Fetch dividend data using Polygon service
 	dividends, err := s.providerService.FetchDividendHistory(ctx, symbol, 10)
-	
+
 	response := map[string]interface{}{
 		"success": err == nil,
 		"symbol":  symbol,

--- a/internal/web/symbol_handlers.go
+++ b/internal/web/symbol_handlers.go
@@ -484,7 +484,7 @@ func (s *Server) symbolUpdatePriceHandler(w http.ResponseWriter, r *http.Request
 	defer cancel()
 
 	// Update symbol price using Polygon service
-	err := s.polygonService.UpdateSymbolPrice(ctx, symbol)
+	err := s.providerService.UpdateSymbolPrice(ctx, symbol)
 	
 	response := map[string]interface{}{
 		"success": err == nil,
@@ -519,7 +519,7 @@ func (s *Server) symbolFetchDividendsHandler(w http.ResponseWriter, r *http.Requ
 	defer cancel()
 
 	// Fetch dividend data using Polygon service
-	dividends, err := s.polygonService.FetchDividendHistory(ctx, symbol, 10)
+	dividends, err := s.providerService.FetchDividendHistory(ctx, symbol, 10)
 	
 	response := map[string]interface{}{
 		"success": err == nil,

--- a/internal/web/templates/settings.html
+++ b/internal/web/templates/settings.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Polygon - Wheeler</title>
+    <title>{{.ProviderName}} Settings - Wheeler</title>
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
     <link rel="stylesheet" href="/static/css/styles.css">
@@ -15,26 +15,26 @@
         <!-- Main Content -->
         <div class="main-content">
             <div class="content-section">
-                <div class="section-title">Polygon</div>
-                <div class="section-subtitle">Configure your Polygon.io API key for live market data</div>
+                <div class="section-title">Market Data Provider</div>
+                <div class="section-subtitle">Manage your {{.ProviderName}} API key for live market data</div>
                 
                 <!-- API Key Configuration Form -->
                 <div class="settings-form-container">
                     <div class="settings-card">
                         <div class="settings-card-header">
                             <i class="fas fa-key"></i>
-                            <h3>Polygon.io API Configuration</h3>
+                            <h3>{{.ProviderName}} API Configuration</h3>
                         </div>
                         <div class="settings-card-body">
                             <form id="apiKeyForm">
                                 <div class="form-group">
                                     <label for="apiKeyInput" class="form-label">API Key</label>
-                                    <input type="password" id="apiKeyInput" class="form-input" 
-                                           placeholder="Enter your Polygon.io API key"
+                                     <input type="password" id="apiKeyInput" class="form-input" 
+                                         placeholder="Enter your {{.ProviderName}} API key"
                                            value="{{if .ApiKey}}{{.ApiKey}}{{end}}">
                                     <div class="form-help">
                                         <i class="fas fa-info-circle"></i>
-                                        Get your free API key from <a href="https://polygon.io" target="_blank" rel="noopener">Polygon.io</a>
+                                        Get your API key from your provider dashboard. Polygon users can visit <a href="https://polygon.io" target="_blank" rel="noopener">Polygon.io</a>
                                     </div>
                                 </div>
                                 <div class="form-group">
@@ -82,16 +82,16 @@
                     <div class="info-card">
                         <div class="info-header">
                             <i class="fas fa-lightbulb"></i>
-                            <h4>About Polygon.io API</h4>
+                            <h4>About {{.ProviderName}}</h4>
                         </div>
                         <div class="info-content">
-                            <p>The Polygon.io API provides real-time and historical market data for stocks, options, and other financial instruments.</p>
+                            <p>{{.ProviderName}} powers live price checks, symbol lookups, and dividend history inside Wheeler.</p>
                             <ul>
-                                <li><strong>Free Tier:</strong> 5 API calls per minute, delayed data</li>
-                                <li><strong>Starter Plan:</strong> 100 API calls per minute, real-time data</li>
-                                <li><strong>Developer Plan:</strong> 1000 API calls per minute, additional endpoints</li>
+                                <li><strong>Requests:</strong> Price updates, symbol insights, and dividend history jobs share the same API quota.</li>
+                                <li><strong>Rate Limits:</strong> Bulk actions pace themselves to respect your provider's published limits.</li>
+                                <li><strong>Default Provider:</strong> Wheeler ships with native Polygon.io support; additional providers can hook into the same workflow.</li>
                             </ul>
-                            <p>Your API key will be used to automatically update stock prices and fetch dividend information.</p>
+                            <p>Need an API key? Sign in to your provider dashboard{{if eq .ProviderName "Polygon.io"}} or <a href="https://polygon.io" target="_blank" rel="noopener">create one at Polygon.io</a>{{end}}.</p>
                         </div>
                     </div>
                 </div>
@@ -267,6 +267,7 @@
     </style>
 
     <script>
+        const providerName = '{{.ProviderName}}';
         // Get API key value from backend
         let currentApiKey = '{{if .ApiKey}}{{.ApiKey}}{{end}}';
         
@@ -335,7 +336,7 @@
                 },
                 body: JSON.stringify({
                     value: apiKey,
-                    description: 'API key for Polygon.io stock market data integration'
+                    description: 'API key for ' + providerName + ' market data integration'
                 })
             })
             .then(response => {
@@ -367,7 +368,7 @@
             const originalText = btn.innerHTML;
             btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Testing...';
             
-            fetch('/api/polygon/test', {
+            fetch('/api/provider/test', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -395,7 +396,7 @@
         document.getElementById('updatePricesBtn').addEventListener('click', function() {
             const btn = this;
             
-            if (!confirm('This will update prices for all symbols using your Polygon.io API quota. Continue?')) {
+            if (!confirm('This will update prices for all symbols using your data provider API quota. Continue?')) {
                 return;
             }
             
@@ -403,7 +404,7 @@
             const originalText = btn.innerHTML;
             btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Updating...';
             
-            fetch('/api/polygon/update-prices', {
+            fetch('/api/provider/update-prices', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',

--- a/test/providers_service_test.go
+++ b/test/providers_service_test.go
@@ -77,10 +77,14 @@ func TestGetAPIKeyStatus_Polygon(t *testing.T) {
 
 			settingService := models.NewSettingService(db.DB)
 			if tt.providerType != "" {
-				settingService.SetValue("DATA_PROVIDER_TYPE", tt.providerType, "")
+				if err := settingService.SetValue("DATA_PROVIDER_TYPE", tt.providerType, ""); err != nil {
+					t.Fatalf("failed to set DATA_PROVIDER_TYPE: %v", err)
+				}
 			}
 			if tt.apiKey != "" {
-				settingService.SetValue("POLYGON_API_KEY", tt.apiKey, "")
+				if err := settingService.SetValue("POLYGON_API_KEY", tt.apiKey, ""); err != nil {
+					t.Fatalf("failed to set POLYGON_API_KEY: %v", err)
+				}
 			}
 
 			symbolService := models.NewSymbolService(db.DB)
@@ -172,16 +176,23 @@ func TestUpdateAllSymbolPrices_MissingAPIKey(t *testing.T) {
 
 	settingService := models.NewSettingService(db.DB)
 	settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
-	// No API key
 
+	// No API key
 	symbolService := models.NewSymbolService(db.DB)
+
 	// Create test symbols
-	symbolService.Create("AAPL")
-	symbolService.Create("GOOGL")
+	_, err := symbolService.Create("AAPL")
+	if err != nil {
+		t.Fatalf("failed to create symbol AAPL: %v", err)
+	}
+	_, err = symbolService.Create("GOOGL")
+	if err != nil {
+		t.Fatalf("failed to create symbol GOOGL: %v", err)
+	}
 
 	service := providers.NewService(symbolService, settingService)
 
-	err := service.UpdateAllSymbolPrices(ctx)
+	err = service.UpdateAllSymbolPrices(ctx)
 	if err == nil {
 		t.Fatal("Expected error without API key, got nil")
 	}

--- a/test/providers_service_test.go
+++ b/test/providers_service_test.go
@@ -108,8 +108,12 @@ func TestGetAPIKeyStatus_UnsupportedProvider(t *testing.T) {
 	db := setupProvidersTestDB(t)
 
 	settingService := models.NewSettingService(db.DB)
-	settingService.SetValue("DATA_PROVIDER_TYPE", "unknown_provider", "")
-	settingService.SetValue("POLYGON_API_KEY", "some_key", "")
+	if err := settingService.SetValue("DATA_PROVIDER_TYPE", "unknown_provider", ""); err != nil {
+		t.Fatalf("failed to set DATA_PROVIDER_TYPE: %v", err)
+	}
+	if err := settingService.SetValue("POLYGON_API_KEY", "some_key", ""); err != nil {
+		t.Fatalf("failed to set POLYGON_API_KEY: %v", err)
+	}
 
 	symbolService := models.NewSymbolService(db.DB)
 	service := providers.NewService(symbolService, settingService)

--- a/test/providers_service_test.go
+++ b/test/providers_service_test.go
@@ -1,33 +1,34 @@
 package test
 
 import (
-"context"
-"os"
-"stonks/internal/database"
-"stonks/internal/models"
-"stonks/internal/providers"
-"testing"
-"time"
+	"context"
+	"os"
+	"stonks/internal/database"
+	"stonks/internal/models"
+	"stonks/internal/providers"
+	"strings"
+	"testing"
+	"time"
 )
 
 // setupProvidersTestDB creates a temporary test database for provider tests
 func setupProvidersTestDB(t *testing.T) *database.DB {
 	testDBPath := "./data/providers_test.db"
-	
+
 	if err := os.Remove(testDBPath); err != nil && !os.IsNotExist(err) {
 		t.Logf("Note: Could not delete existing test database: %v", err)
 	}
-	
+
 	db, err := database.NewDB(testDBPath)
 	if err != nil {
 		t.Fatalf("Failed to create test database: %v", err)
 	}
-	
+
 	t.Cleanup(func() {
 		db.Close()
 		os.Remove(testDBPath)
 	})
-	
+
 	return db
 }
 
@@ -72,20 +73,20 @@ func TestGetAPIKeyStatus_Polygon(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-db := setupProvidersTestDB(t)
+			db := setupProvidersTestDB(t)
 
-settingService := models.NewSettingService(db.DB)
-if tt.providerType != "" {
-settingService.SetValue("DATA_PROVIDER_TYPE", tt.providerType, "")
-}
-if tt.apiKey != "" {
-settingService.SetValue("POLYGON_API_KEY", tt.apiKey, "")
-}
+			settingService := models.NewSettingService(db.DB)
+			if tt.providerType != "" {
+				settingService.SetValue("DATA_PROVIDER_TYPE", tt.providerType, "")
+			}
+			if tt.apiKey != "" {
+				settingService.SetValue("POLYGON_API_KEY", tt.apiKey, "")
+			}
 
-symbolService := models.NewSymbolService(db.DB)
-service := providers.NewService(symbolService, settingService)
+			symbolService := models.NewSymbolService(db.DB)
+			service := providers.NewService(symbolService, settingService)
 
-status := service.GetAPIKeyStatus()
+			status := service.GetAPIKeyStatus()
 
 			if status.Configured != tt.wantConfigured {
 				t.Errorf("Expected Configured=%v, got %v", tt.wantConfigured, status.Configured)
@@ -129,203 +130,191 @@ func TestUpdateSymbolPrice_MissingAPIKey(t *testing.T) {
 	settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
 	// Don't set POLYGON_API_KEY
 
-symbolService := models.NewSymbolService(db.DB)
-service := providers.NewService(symbolService, settingService)
+	symbolService := models.NewSymbolService(db.DB)
+	service := providers.NewService(symbolService, settingService)
 
-err := service.UpdateSymbolPrice(ctx, "AAPL")
-if err == nil {
-t.Fatal("Expected error when API key is missing, got nil")
-}
+	err := service.UpdateSymbolPrice(ctx, "AAPL")
+	if err == nil {
+		t.Fatal("Expected error when API key is missing, got nil")
+	}
 
-if !stringContains(err.Error(), "failed to get provider") {
-t.Errorf("Expected error about provider, got: %v", err)
-}
+	if !strings.Contains(err.Error(), "failed to get provider") {
+		t.Errorf("Expected error about provider, got: %v", err)
+	}
 }
 
 // TestUpdateSymbolPrice_UnsupportedProvider tests error with unsupported provider
 func TestUpdateSymbolPrice_UnsupportedProvider(t *testing.T) {
-ctx := context.Background()
-db := setupProvidersTestDB(t)
+	ctx := context.Background()
+	db := setupProvidersTestDB(t)
 
-settingService := models.NewSettingService(db.DB)
-settingService.SetValue("DATA_PROVIDER_TYPE", "unsupported", "")
-settingService.SetValue("POLYGON_API_KEY", "test_key", "")
+	settingService := models.NewSettingService(db.DB)
+	settingService.SetValue("DATA_PROVIDER_TYPE", "unsupported", "")
+	settingService.SetValue("POLYGON_API_KEY", "test_key", "")
 
-symbolService := models.NewSymbolService(db.DB)
-service := providers.NewService(symbolService, settingService)
+	symbolService := models.NewSymbolService(db.DB)
+	service := providers.NewService(symbolService, settingService)
 
-err := service.UpdateSymbolPrice(ctx, "AAPL")
-if err == nil {
-t.Fatal("Expected error when provider is unsupported, got nil")
-}
+	err := service.UpdateSymbolPrice(ctx, "AAPL")
+	if err == nil {
+		t.Fatal("Expected error when provider is unsupported, got nil")
+	}
 
-if !stringContains(err.Error(), "failed to get provider") {
-t.Errorf("Expected error about provider, got: %v", err)
-}
+	if !strings.Contains(err.Error(), "failed to get provider") {
+		t.Errorf("Expected error about provider, got: %v", err)
+	}
 }
 
 // TestUpdateAllSymbolPrices_MissingAPIKey tests bulk update without API key
 func TestUpdateAllSymbolPrices_MissingAPIKey(t *testing.T) {
-ctx := context.Background()
-db := setupProvidersTestDB(t)
+	ctx := context.Background()
+	db := setupProvidersTestDB(t)
 
-settingService := models.NewSettingService(db.DB)
-settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
-// No API key
+	settingService := models.NewSettingService(db.DB)
+	settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
+	// No API key
 
-symbolService := models.NewSymbolService(db.DB)
-// Create test symbols
-symbolService.Create("AAPL")
-symbolService.Create("GOOGL")
+	symbolService := models.NewSymbolService(db.DB)
+	// Create test symbols
+	symbolService.Create("AAPL")
+	symbolService.Create("GOOGL")
 
-service := providers.NewService(symbolService, settingService)
+	service := providers.NewService(symbolService, settingService)
 
-err := service.UpdateAllSymbolPrices(ctx)
-if err == nil {
-t.Fatal("Expected error without API key, got nil")
-}
+	err := service.UpdateAllSymbolPrices(ctx)
+	if err == nil {
+		t.Fatal("Expected error without API key, got nil")
+	}
 }
 
 // TestFetchSymbolDetails_MissingAPIKey tests fetch details without API key
 func TestFetchSymbolDetails_MissingAPIKey(t *testing.T) {
-ctx := context.Background()
-db := setupProvidersTestDB(t)
+	ctx := context.Background()
+	db := setupProvidersTestDB(t)
 
-settingService := models.NewSettingService(db.DB)
-settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
-// No API key - should fail
+	settingService := models.NewSettingService(db.DB)
+	settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
+	// No API key - should fail
 
-symbolService := models.NewSymbolService(db.DB)
-service := providers.NewService(symbolService, settingService)
+	symbolService := models.NewSymbolService(db.DB)
+	service := providers.NewService(symbolService, settingService)
 
-_, err := service.FetchSymbolDetails(ctx, "AAPL")
-if err == nil {
-t.Fatal("Expected error without API key, got nil")
-}
+	_, err := service.FetchSymbolDetails(ctx, "AAPL")
+	if err == nil {
+		t.Fatal("Expected error without API key, got nil")
+	}
 
-if !stringContains(err.Error(), "failed to get provider") {
-t.Errorf("Expected provider error, got: %v", err)
-}
+	if !strings.Contains(err.Error(), "failed to get provider") {
+		t.Errorf("Expected provider error, got: %v", err)
+	}
 }
 
 // TestFetchDividendHistory_MissingAPIKey tests dividend history without API key
 func TestFetchDividendHistory_MissingAPIKey(t *testing.T) {
-ctx := context.Background()
-db := setupProvidersTestDB(t)
+	ctx := context.Background()
+	db := setupProvidersTestDB(t)
 
-settingService := models.NewSettingService(db.DB)
-settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
-// No API key
+	settingService := models.NewSettingService(db.DB)
+	settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
+	// No API key
 
-symbolService := models.NewSymbolService(db.DB)
-service := providers.NewService(symbolService, settingService)
+	symbolService := models.NewSymbolService(db.DB)
+	service := providers.NewService(symbolService, settingService)
 
-_, err := service.FetchDividendHistory(ctx, "AAPL", 10)
-if err == nil {
-t.Fatal("Expected error without API key, got nil")
-}
+	_, err := service.FetchDividendHistory(ctx, "AAPL", 10)
+	if err == nil {
+		t.Fatal("Expected error without API key, got nil")
+	}
 
-if !stringContains(err.Error(), "failed to get provider") {
-t.Errorf("Expected provider error, got: %v", err)
-}
+	if !strings.Contains(err.Error(), "failed to get provider") {
+		t.Errorf("Expected provider error, got: %v", err)
+	}
 }
 
 // TestTestConnection_MissingAPIKey tests connection test without API key
 func TestTestConnection_MissingAPIKey(t *testing.T) {
-ctx := context.Background()
-db := setupProvidersTestDB(t)
+	ctx := context.Background()
+	db := setupProvidersTestDB(t)
 
-settingService := models.NewSettingService(db.DB)
-settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
-// No API key
+	settingService := models.NewSettingService(db.DB)
+	settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
+	// No API key
 
-symbolService := models.NewSymbolService(db.DB)
-service := providers.NewService(symbolService, settingService)
+	symbolService := models.NewSymbolService(db.DB)
+	service := providers.NewService(symbolService, settingService)
 
-err := service.TestConnection(ctx)
-if err == nil {
-t.Fatal("Expected error without API key, got nil")
-}
+	err := service.TestConnection(ctx)
+	if err == nil {
+		t.Fatal("Expected error without API key, got nil")
+	}
 }
 
 // TestGetRateLimitDelay tests rate limit delay configuration
 func TestGetRateLimitDelay(t *testing.T) {
-tests := []struct {
-name         string
-providerType string
-wantDelay    time.Duration
-}{
-{
-name:         "polygon provider",
-providerType: "polygon",
-wantDelay:    12 * time.Second,
-},
-{
-name:         "default provider",
-providerType: "",
-wantDelay:    12 * time.Second, // Defaults to polygon
-},
-{
-name:         "unknown provider",
-providerType: "unknown",
-wantDelay:    10 * time.Second,
-},
-}
+	tests := []struct {
+		name         string
+		providerType string
+		wantDelay    time.Duration
+	}{
+		{
+			name:         "polygon provider",
+			providerType: "polygon",
+			wantDelay:    12 * time.Second,
+		},
+		{
+			name:         "default provider",
+			providerType: "",
+			wantDelay:    12 * time.Second, // Defaults to polygon
+		},
+		{
+			name:         "unknown provider",
+			providerType: "unknown",
+			wantDelay:    10 * time.Second,
+		},
+	}
 
-for _, tt := range tests {
-t.Run(tt.name, func(t *testing.T) {
-db := setupProvidersTestDB(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := setupProvidersTestDB(t)
 
-settingService := models.NewSettingService(db.DB)
-if tt.providerType != "" {
-settingService.SetValue("DATA_PROVIDER_TYPE", tt.providerType, "")
-}
+			settingService := models.NewSettingService(db.DB)
+			if tt.providerType != "" {
+				settingService.SetValue("DATA_PROVIDER_TYPE", tt.providerType, "")
+			}
 
-symbolService := models.NewSymbolService(db.DB)
-service := providers.NewService(symbolService, settingService)
+			symbolService := models.NewSymbolService(db.DB)
+			service := providers.NewService(symbolService, settingService)
 
-delay := service.GetRateLimitDelay()
-if delay != tt.wantDelay {
-t.Errorf("Expected delay %v, got %v", tt.wantDelay, delay)
-}
-})
-}
+			delay := service.GetRateLimitDelay()
+			if delay != tt.wantDelay {
+				t.Errorf("Expected delay %v, got %v", tt.wantDelay, delay)
+			}
+		})
+	}
 }
 
 // TestDebugLogging tests that debug logging can be controlled
 func TestDebugLogging(t *testing.T) {
-db := setupProvidersTestDB(t)
+	db := setupProvidersTestDB(t)
 
-settingService := models.NewSettingService(db.DB)
-settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
-settingService.SetValue("POLYGON_API_KEY", "test_key_12345", "")
+	settingService := models.NewSettingService(db.DB)
+	settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
+	settingService.SetValue("POLYGON_API_KEY", "test_key_12345", "")
 
-symbolService := models.NewSymbolService(db.DB)
-service := providers.NewService(symbolService, settingService)
-
-// Test with DEBUG_PROVIDERS=1
-os.Setenv("DEBUG_PROVIDERS", "1")
-defer os.Unsetenv("DEBUG_PROVIDERS")
-
-// This test just verifies that the service doesn't panic when DEBUG_PROVIDERS is set
+	symbolService := models.NewSymbolService(db.DB)
+	// Test with DEBUG_PROVIDERS=1
+	os.Setenv("DEBUG_PROVIDERS", "1")
+	defer os.Unsetenv("DEBUG_PROVIDERS")
+	serviceDebug := providers.NewService(symbolService, settingService)
+	// This test just verifies that the service doesn't panic when DEBUG_PROVIDERS is set
 	// In a real scenario, we'd test actual provider behavior
-if service == nil {
-t.Fatal("Expected service, got nil")
-}
-
-// Test without DEBUG_PROVIDERS
-os.Unsetenv("DEBUG_PROVIDERS")
-if service == nil {
-t.Fatal("Expected service, got nil")
-}
-}
-
-// Helper function to check if a string contains a substring
-func stringContains(s, substr string) bool {
-for i := 0; i <= len(s)-len(substr); i++ {
-if s[i:i+len(substr)] == substr {
-return true
-}
-}
-return false
+	if serviceDebug == nil {
+		t.Fatal("Expected service with debug enabled, got nil")
+	}
+	// Test without DEBUG_PROVIDERS
+	os.Unsetenv("DEBUG_PROVIDERS")
+	service := providers.NewService(symbolService, settingService)
+	if service == nil {
+		t.Fatal("Expected service with debug disabled, got nil")
+	}
 }

--- a/test/providers_service_test.go
+++ b/test/providers_service_test.go
@@ -196,7 +196,7 @@ func TestUpdateAllSymbolPrices_MissingAPIKey(t *testing.T) {
 
 	service := providers.NewService(symbolService, settingService)
 
-	err = service.UpdateAllSymbolPrices(ctx)
+	_, err = service.UpdateAllSymbolPrices(ctx)
 	if err == nil {
 		t.Fatal("Expected error without API key, got nil")
 	}

--- a/test/providers_service_test.go
+++ b/test/providers_service_test.go
@@ -1,0 +1,331 @@
+package test
+
+import (
+"context"
+"os"
+"stonks/internal/database"
+"stonks/internal/models"
+"stonks/internal/providers"
+"testing"
+"time"
+)
+
+// setupProvidersTestDB creates a temporary test database for provider tests
+func setupProvidersTestDB(t *testing.T) *database.DB {
+	testDBPath := "./data/providers_test.db"
+	
+	if err := os.Remove(testDBPath); err != nil && !os.IsNotExist(err) {
+		t.Logf("Note: Could not delete existing test database: %v", err)
+	}
+	
+	db, err := database.NewDB(testDBPath)
+	if err != nil {
+		t.Fatalf("Failed to create test database: %v", err)
+	}
+	
+	t.Cleanup(func() {
+		db.Close()
+		os.Remove(testDBPath)
+	})
+	
+	return db
+}
+
+// TestGetAPIKeyStatus_Polygon tests API key status with Polygon provider
+func TestGetAPIKeyStatus_Polygon(t *testing.T) {
+	tests := []struct {
+		name           string
+		providerType   string
+		apiKey         string
+		wantConfigured bool
+		wantMasked     string
+	}{
+		{
+			name:           "configured with long key",
+			providerType:   "polygon",
+			apiKey:         "abcdefghijklmnop",
+			wantConfigured: true,
+			wantMasked:     "abc...nop",
+		},
+		{
+			name:           "configured with short key",
+			providerType:   "polygon",
+			apiKey:         "abc",
+			wantConfigured: true,
+			wantMasked:     "***",
+		},
+		{
+			name:           "not configured",
+			providerType:   "polygon",
+			apiKey:         "",
+			wantConfigured: false,
+			wantMasked:     "",
+		},
+		{
+			name:           "default to polygon when type not set",
+			providerType:   "",
+			apiKey:         "testkey123",
+			wantConfigured: true,
+			wantMasked:     "tes...123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+db := setupProvidersTestDB(t)
+
+settingService := models.NewSettingService(db.DB)
+if tt.providerType != "" {
+settingService.SetValue("DATA_PROVIDER_TYPE", tt.providerType, "")
+}
+if tt.apiKey != "" {
+settingService.SetValue("POLYGON_API_KEY", tt.apiKey, "")
+}
+
+symbolService := models.NewSymbolService(db.DB)
+service := providers.NewService(symbolService, settingService)
+
+status := service.GetAPIKeyStatus()
+
+			if status.Configured != tt.wantConfigured {
+				t.Errorf("Expected Configured=%v, got %v", tt.wantConfigured, status.Configured)
+			}
+
+			if status.Masked != tt.wantMasked {
+				t.Errorf("Expected Masked=%q, got %q", tt.wantMasked, status.Masked)
+			}
+		})
+	}
+}
+
+// TestGetAPIKeyStatus_UnsupportedProvider tests API key status with unsupported provider
+func TestGetAPIKeyStatus_UnsupportedProvider(t *testing.T) {
+	db := setupProvidersTestDB(t)
+
+	settingService := models.NewSettingService(db.DB)
+	settingService.SetValue("DATA_PROVIDER_TYPE", "unknown_provider", "")
+	settingService.SetValue("POLYGON_API_KEY", "some_key", "")
+
+	symbolService := models.NewSymbolService(db.DB)
+	service := providers.NewService(symbolService, settingService)
+
+	status := service.GetAPIKeyStatus()
+
+	if status.Configured {
+		t.Error("Expected Configured=false for unsupported provider")
+	}
+
+	if status.Masked != "" {
+		t.Errorf("Expected empty Masked for unsupported provider, got %q", status.Masked)
+	}
+}
+
+// TestUpdateSymbolPrice_MissingAPIKey tests error when API key is missing
+func TestUpdateSymbolPrice_MissingAPIKey(t *testing.T) {
+	ctx := context.Background()
+	db := setupProvidersTestDB(t)
+
+	settingService := models.NewSettingService(db.DB)
+	settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
+	// Don't set POLYGON_API_KEY
+
+symbolService := models.NewSymbolService(db.DB)
+service := providers.NewService(symbolService, settingService)
+
+err := service.UpdateSymbolPrice(ctx, "AAPL")
+if err == nil {
+t.Fatal("Expected error when API key is missing, got nil")
+}
+
+if !stringContains(err.Error(), "failed to get provider") {
+t.Errorf("Expected error about provider, got: %v", err)
+}
+}
+
+// TestUpdateSymbolPrice_UnsupportedProvider tests error with unsupported provider
+func TestUpdateSymbolPrice_UnsupportedProvider(t *testing.T) {
+ctx := context.Background()
+db := setupProvidersTestDB(t)
+
+settingService := models.NewSettingService(db.DB)
+settingService.SetValue("DATA_PROVIDER_TYPE", "unsupported", "")
+settingService.SetValue("POLYGON_API_KEY", "test_key", "")
+
+symbolService := models.NewSymbolService(db.DB)
+service := providers.NewService(symbolService, settingService)
+
+err := service.UpdateSymbolPrice(ctx, "AAPL")
+if err == nil {
+t.Fatal("Expected error when provider is unsupported, got nil")
+}
+
+if !stringContains(err.Error(), "failed to get provider") {
+t.Errorf("Expected error about provider, got: %v", err)
+}
+}
+
+// TestUpdateAllSymbolPrices_MissingAPIKey tests bulk update without API key
+func TestUpdateAllSymbolPrices_MissingAPIKey(t *testing.T) {
+ctx := context.Background()
+db := setupProvidersTestDB(t)
+
+settingService := models.NewSettingService(db.DB)
+settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
+// No API key
+
+symbolService := models.NewSymbolService(db.DB)
+// Create test symbols
+symbolService.Create("AAPL")
+symbolService.Create("GOOGL")
+
+service := providers.NewService(symbolService, settingService)
+
+err := service.UpdateAllSymbolPrices(ctx)
+if err == nil {
+t.Fatal("Expected error without API key, got nil")
+}
+}
+
+// TestFetchSymbolDetails_MissingAPIKey tests fetch details without API key
+func TestFetchSymbolDetails_MissingAPIKey(t *testing.T) {
+ctx := context.Background()
+db := setupProvidersTestDB(t)
+
+settingService := models.NewSettingService(db.DB)
+settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
+// No API key - should fail
+
+symbolService := models.NewSymbolService(db.DB)
+service := providers.NewService(symbolService, settingService)
+
+_, err := service.FetchSymbolDetails(ctx, "AAPL")
+if err == nil {
+t.Fatal("Expected error without API key, got nil")
+}
+
+if !stringContains(err.Error(), "failed to get provider") {
+t.Errorf("Expected provider error, got: %v", err)
+}
+}
+
+// TestFetchDividendHistory_MissingAPIKey tests dividend history without API key
+func TestFetchDividendHistory_MissingAPIKey(t *testing.T) {
+ctx := context.Background()
+db := setupProvidersTestDB(t)
+
+settingService := models.NewSettingService(db.DB)
+settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
+// No API key
+
+symbolService := models.NewSymbolService(db.DB)
+service := providers.NewService(symbolService, settingService)
+
+_, err := service.FetchDividendHistory(ctx, "AAPL", 10)
+if err == nil {
+t.Fatal("Expected error without API key, got nil")
+}
+
+if !stringContains(err.Error(), "failed to get provider") {
+t.Errorf("Expected provider error, got: %v", err)
+}
+}
+
+// TestTestConnection_MissingAPIKey tests connection test without API key
+func TestTestConnection_MissingAPIKey(t *testing.T) {
+ctx := context.Background()
+db := setupProvidersTestDB(t)
+
+settingService := models.NewSettingService(db.DB)
+settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
+// No API key
+
+symbolService := models.NewSymbolService(db.DB)
+service := providers.NewService(symbolService, settingService)
+
+err := service.TestConnection(ctx)
+if err == nil {
+t.Fatal("Expected error without API key, got nil")
+}
+}
+
+// TestGetRateLimitDelay tests rate limit delay configuration
+func TestGetRateLimitDelay(t *testing.T) {
+tests := []struct {
+name         string
+providerType string
+wantDelay    time.Duration
+}{
+{
+name:         "polygon provider",
+providerType: "polygon",
+wantDelay:    12 * time.Second,
+},
+{
+name:         "default provider",
+providerType: "",
+wantDelay:    12 * time.Second, // Defaults to polygon
+},
+{
+name:         "unknown provider",
+providerType: "unknown",
+wantDelay:    10 * time.Second,
+},
+}
+
+for _, tt := range tests {
+t.Run(tt.name, func(t *testing.T) {
+db := setupProvidersTestDB(t)
+
+settingService := models.NewSettingService(db.DB)
+if tt.providerType != "" {
+settingService.SetValue("DATA_PROVIDER_TYPE", tt.providerType, "")
+}
+
+symbolService := models.NewSymbolService(db.DB)
+service := providers.NewService(symbolService, settingService)
+
+delay := service.GetRateLimitDelay()
+if delay != tt.wantDelay {
+t.Errorf("Expected delay %v, got %v", tt.wantDelay, delay)
+}
+})
+}
+}
+
+// TestDebugLogging tests that debug logging can be controlled
+func TestDebugLogging(t *testing.T) {
+db := setupProvidersTestDB(t)
+
+settingService := models.NewSettingService(db.DB)
+settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
+settingService.SetValue("POLYGON_API_KEY", "test_key_12345", "")
+
+symbolService := models.NewSymbolService(db.DB)
+service := providers.NewService(symbolService, settingService)
+
+// Test with DEBUG_PROVIDERS=1
+os.Setenv("DEBUG_PROVIDERS", "1")
+defer os.Unsetenv("DEBUG_PROVIDERS")
+
+// This test just verifies that the service doesn't panic when DEBUG_PROVIDERS is set
+	// In a real scenario, we'd test actual provider behavior
+if service == nil {
+t.Fatal("Expected service, got nil")
+}
+
+// Test without DEBUG_PROVIDERS
+os.Unsetenv("DEBUG_PROVIDERS")
+if service == nil {
+t.Fatal("Expected service, got nil")
+}
+}
+
+// Helper function to check if a string contains a substring
+func stringContains(s, substr string) bool {
+for i := 0; i <= len(s)-len(substr); i++ {
+if s[i:i+len(substr)] == substr {
+return true
+}
+}
+return false
+}

--- a/test/providers_service_test.go
+++ b/test/providers_service_test.go
@@ -135,8 +135,10 @@ func TestUpdateSymbolPrice_MissingAPIKey(t *testing.T) {
 	db := setupProvidersTestDB(t)
 
 	settingService := models.NewSettingService(db.DB)
-	settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
-	// Don't set POLYGON_API_KEY
+	if err := settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", ""); err != nil {
+		t.Fatalf("failed to set DATA_PROVIDER_TYPE: %v", err)
+	}
+	// Intentionally don't set POLYGON_API_KEY to test missing key scenario
 
 	symbolService := models.NewSymbolService(db.DB)
 	service := providers.NewService(symbolService, settingService)
@@ -157,8 +159,12 @@ func TestUpdateSymbolPrice_UnsupportedProvider(t *testing.T) {
 	db := setupProvidersTestDB(t)
 
 	settingService := models.NewSettingService(db.DB)
-	settingService.SetValue("DATA_PROVIDER_TYPE", "unsupported", "")
-	settingService.SetValue("POLYGON_API_KEY", "test_key", "")
+	if err := settingService.SetValue("DATA_PROVIDER_TYPE", "unsupported", ""); err != nil {
+		t.Fatalf("failed to set DATA_PROVIDER_TYPE: %v", err)
+	}
+	if err := settingService.SetValue("POLYGON_API_KEY", "test_key", ""); err != nil {
+		t.Fatalf("failed to set POLYGON_API_KEY: %v", err)
+	}
 
 	symbolService := models.NewSymbolService(db.DB)
 	service := providers.NewService(symbolService, settingService)
@@ -179,7 +185,9 @@ func TestUpdateAllSymbolPrices_MissingAPIKey(t *testing.T) {
 	db := setupProvidersTestDB(t)
 
 	settingService := models.NewSettingService(db.DB)
-	settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
+	if err := settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", ""); err != nil {
+		t.Fatalf("failed to set DATA_PROVIDER_TYPE: %v", err)
+	}
 
 	// No API key
 	symbolService := models.NewSymbolService(db.DB)
@@ -208,7 +216,9 @@ func TestFetchSymbolDetails_MissingAPIKey(t *testing.T) {
 	db := setupProvidersTestDB(t)
 
 	settingService := models.NewSettingService(db.DB)
-	settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
+	if err := settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", ""); err != nil {
+		t.Fatalf("failed to set DATA_PROVIDER_TYPE: %v", err)
+	}
 	// No API key - should fail
 
 	symbolService := models.NewSymbolService(db.DB)
@@ -230,7 +240,9 @@ func TestFetchDividendHistory_MissingAPIKey(t *testing.T) {
 	db := setupProvidersTestDB(t)
 
 	settingService := models.NewSettingService(db.DB)
-	settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
+	if err := settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", ""); err != nil {
+		t.Fatalf("failed to set DATA_PROVIDER_TYPE: %v", err)
+	}
 	// No API key
 
 	symbolService := models.NewSymbolService(db.DB)
@@ -252,7 +264,9 @@ func TestTestConnection_MissingAPIKey(t *testing.T) {
 	db := setupProvidersTestDB(t)
 
 	settingService := models.NewSettingService(db.DB)
-	settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
+	if err := settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", ""); err != nil {
+		t.Fatalf("failed to set DATA_PROVIDER_TYPE: %v", err)
+	}
 	// No API key
 
 	symbolService := models.NewSymbolService(db.DB)
@@ -294,7 +308,9 @@ func TestGetRateLimitDelay(t *testing.T) {
 
 			settingService := models.NewSettingService(db.DB)
 			if tt.providerType != "" {
-				settingService.SetValue("DATA_PROVIDER_TYPE", tt.providerType, "")
+				if err := settingService.SetValue("DATA_PROVIDER_TYPE", tt.providerType, ""); err != nil {
+					t.Fatalf("failed to set DATA_PROVIDER_TYPE: %v", err)
+				}
 			}
 
 			symbolService := models.NewSymbolService(db.DB)
@@ -313,8 +329,12 @@ func TestDebugLogging(t *testing.T) {
 	db := setupProvidersTestDB(t)
 
 	settingService := models.NewSettingService(db.DB)
-	settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
-	settingService.SetValue("POLYGON_API_KEY", "test_key_12345", "")
+	if err := settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", ""); err != nil {
+		t.Fatalf("failed to set DATA_PROVIDER_TYPE: %v", err)
+	}
+	if err := settingService.SetValue("POLYGON_API_KEY", "test_key_12345", ""); err != nil {
+		t.Fatalf("failed to set POLYGON_API_KEY: %v", err)
+	}
 
 	symbolService := models.NewSymbolService(db.DB)
 	// Test with DEBUG_PROVIDERS=1


### PR DESCRIPTION
This update introduces a provider abstraction layer to support multiple market data sources, allowing for easier integration of new providers like Yahoo Finance. The existing Polygon.io integration remains intact, ensuring backward compatibility. Key changes include the creation of a `Provider` interface, implementation of a `PolygonProvider`, and modifications to the server to utilize the new provider service. Additionally, comprehensive tests for API key handling and rate limiting have been added, along with updated development instructions.

Fixes #52

Original fork PR for reference: https://github.com/phbrgnomo/wheeler/pull/2