### PR TITLE
Enhance Docker security

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -32,7 +32,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -41,7 +41,7 @@ jobs:
             type=sha,prefix={{branch}}-
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25
         with:
           context: .
           push: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,43 @@
 .claude
+
+# Local data files
 data/
+
+# Local env/secret files
+.env
+.env.*
+
+# Build artifacts
+bin/
+dist/
+tmp/
+coverage/
+
+# Logs
+*.log
+
+# Editor/OS
+.vscode/
+.idea/
+.DS_Store
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+
+# End of https://www.toptal.com/developers/gitignore/api/go

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .claude
-./data/.
+data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,7 @@ RUN mkdir -p /app/data
 # Create an unprivileged system user and set ownership of necessary writable directories
 # Use Alpine addgroup/adduser to create a system user `appuser` with home `/home/appuser`
 RUN addgroup -S appuser \
- && adduser -S -G appuser -h /home/appuser appuser \
- && mkdir -p /home/appuser \
+ && adduser -S -G appuser -h /home/appuser appuser
  && chown -R appuser:appuser /home/appuser /app/data
 
 # Switch to the unprivileged user for runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,11 +35,12 @@ COPY --from=builder /app/internal/database/wheel_strategy_example.sql ./internal
 # Create data directory for SQLite database
 RUN mkdir -p /app/data
 
-# Create an unprivileged system user and set ownership of app files
-# Use Alpine addgroup/adduser to create a system user `appuser` with home `/app`
+# Create an unprivileged system user and set ownership of necessary writable directories
+# Use Alpine addgroup/adduser to create a system user `appuser` with home `/home/appuser`
 RUN addgroup -S appuser \
- && adduser -S -G appuser -h /app appuser \
- && chown -R appuser:appuser /app
+ && adduser -S -G appuser -h /home/appuser appuser \
+ && mkdir -p /home/appuser \
+ && chown -R appuser:appuser /home/appuser /app/data
 
 # Switch to the unprivileged user for runtime
 USER appuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,36 +16,28 @@ COPY . .
 # Build the application with CGO enabled for SQLite
 RUN CGO_ENABLED=1 go build -o wheeler .
 
+
 # Runtime stage
 FROM alpine:3.19
 
 WORKDIR /app
 
-# Copy the binary from builder
+# Copy app binary, templates, static assets and DB schema from builder
 COPY --from=builder /app/wheeler .
-
-# Copy web templates and static assets
 COPY --from=builder /app/internal/web/templates ./internal/web/templates
 COPY --from=builder /app/internal/web/static ./internal/web/static
-
-# Copy database schema files
 COPY --from=builder /app/internal/database/schema.sql ./internal/database/schema.sql
 COPY --from=builder /app/internal/database/wheel_strategy_example.sql ./internal/database/wheel_strategy_example.sql
+COPY --from=builder /app/internal/database/wheel_strategy_example_clean.sql ./internal/database/wheel_strategy_example_clean.sql
 
-# Create data directory for SQLite database
-RUN mkdir -p /app/data
+# Create data directory, create unprivileged user, set ownership and ensure binary is executable
+RUN mkdir -p /app/data \
+ && addgroup -S appuser \
+ && adduser -S -G appuser -h /app appuser \
+ && chown -R appuser:appuser /app \
+ && chmod +x /app/wheeler
 
-# Create an unprivileged system user and set ownership of necessary writable directories
-# Use Alpine addgroup/adduser to create a system user `appuser` with home `/home/appuser`
-RUN addgroup -S appuser \
- && adduser -S -G appuser -h /home/appuser appuser
- && chown -R appuser:appuser /home/appuser /app/data
-
-# Switch to the unprivileged user for runtime
+# Switch to unprivileged user and run
 USER appuser
-
-# Expose the web server port
 EXPOSE 8080
-
-# Run the application
 CMD ["./wheeler"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY . .
 RUN CGO_ENABLED=1 go build -o wheeler .
 
 # Runtime stage
-FROM alpine:latest
+FROM alpine:3.19
 
 WORKDIR /app
 
@@ -34,6 +34,15 @@ COPY --from=builder /app/internal/database/wheel_strategy_example.sql ./internal
 
 # Create data directory for SQLite database
 RUN mkdir -p /app/data
+
+# Create an unprivileged system user and set ownership of app files
+# Use Alpine addgroup/adduser to create a system user `appuser` with home `/app`
+RUN addgroup -S appuser \
+ && adduser -S -G appuser -h /app appuser \
+ && chown -R appuser:appuser /app
+
+# Switch to the unprivileged user for runtime
+USER appuser
 
 # Expose the web server port
 EXPOSE 8080


### PR DESCRIPTION
Improve Docker security by fixing the image version, creating a non-root user, and organizing the Dockerfile for better clarity and efficiency.

Summary by Sourcery
Pin Docker base image and GitHub Actions to specific versions and run the application container as a non-root user for improved security.

Enhancements:

Use a fixed Alpine base image version and run the runtime container as an unprivileged user with appropriate ownership and permissions.
Simplify and organize Dockerfile runtime stage asset copying and directory setup.
CI:

Pin GitHub Actions used in the Docker publish workflow to specific commit SHAs for more deterministic CI behavior.