### PR TITLE
Add google finance and yahoo finance as free data providers

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,172 @@
+# Wheeler Development Instructions for AI Agents
+
+## Project Context
+Wheeler is a Go web application for tracking options trading strategies (particularly "wheel strategy"), with SQLite persistence and Polygon.io market data integration. The core domain involves sophisticated financial tracking: cash-secured puts, covered calls, stock assignments, dividends, and Treasury collateral management.
+
+## Architecture Overview
+
+### Service Layer Pattern (`internal/models/`)
+Each domain entity has a dedicated service struct wrapping the `*sql.DB`:
+- **OptionService**: Manages Put/Call lifecycle with automatic commission calculation ($0.65/contract)
+- **LongPositionService**: Tracks stock holdings from put assignments to call assignments
+- **SymbolService**: Maintains stock metadata (price, dividend, P/E ratio)
+- **TreasuryService**: Handles collateral with dynamic balance adjustments
+- **DividendService**: Records dividend payments and yield calculations
+- **MetricService**: Aggregates portfolio performance and P&L calculations
+
+Services use **ID-based CRUD** operations (`GetByID`, `Update`, `Delete`) for web-friendly REST patterns. Compound key fallbacks exist for backward compatibility but are deprecated.
+
+### Database Design (`internal/database/`)
+**Hybrid Primary Key Strategy**:
+- **Transactional tables** use `INTEGER PRIMARY KEY AUTOINCREMENT` for easier HTTP operations: `options.id`, `long_positions.id`, `dividends.id`
+- **Reference tables** use natural keys: `symbols.symbol`, `treasuries.cuspid`, `settings.name`
+- **Unique constraints** prevent duplicate business records (e.g., same option opened twice)
+
+**Schema Management**:
+- `schema.sql` is the single source of truth (embedded via `//go:embed`)
+- No migration files; database setup uses `CREATE TABLE IF NOT EXISTS`
+- SQLite WAL mode with foreign keys enabled: `?_busy_timeout=10000&_journal_mode=WAL&_foreign_keys=on`
+
+### Web Layer (`internal/web/`)
+**Handler Organization**:
+- `server.go`: Server struct initialization, routing, template loading with custom functions
+- `*_handlers.go`: Domain-specific handlers (dashboard, options, symbols, etc.)
+- `types.go`: Web-specific data structures for JSON API responses
+- `utility_handlers.go`: Shared helper functions
+
+**Template Pattern**:
+- HTML templates in `templates/` use Go templating with custom functions (`groupByExpiration`, `add`, `mul`)
+- Shared component: `_symbol_modal.html` for reusable symbol entry
+- Chart.js for interactive visualizations (scatter plots, pie charts with click navigation)
+
+### External Integration (`internal/polygon/`)
+- `client.go`: HTTP client wrapping Polygon.io REST API
+- `service.go`: Business logic layer for fetching quotes, aggregates, and ticker details
+- API key stored in `settings` table, retrieved via `SettingService`
+
+## Development Commands
+
+### Quick Start
+```bash
+go run main.go                    # Start web server on :8080
+make build                        # Build to bin/wheeler with CGO enabled
+make test                         # Run all tests (requires CGO for SQLite)
+```
+
+### Database Operations
+- **Multiple databases**: Current DB tracked in `./data/currentdb` file
+- **Test data**: Click "Generate Test Data" in Help → Tutorial (loads `wheel_strategy_example.sql`)
+- **Backups**: Manual backup via Admin page saves to `./data/backups/`
+
+### Testing
+- Unit tests alongside code files (`*_test.go`)
+- Integration tests require live Polygon.io API key: `internal/polygon/live_integration_test.go`
+- Test databases automatically cleaned: `rm -f test_*.db`
+
+## Key Patterns & Conventions
+
+### Financial Calculations
+```go
+// Options commission is always $0.65 per contract
+const OptionCommissionPerContract = 0.65
+
+// P&L calculation includes commission deductions
+profit := (premium - exitPrice) * float64(contracts) * 100 - commission
+```
+
+### Service Method Signatures
+```go
+// ID-based operations (preferred)
+func (s *OptionService) GetByID(id int) (*Option, error)
+func (s *OptionService) Update(id int, updates map[string]interface{}) error
+
+// Compound key fallbacks (legacy compatibility)
+func (s *OptionService) GetByCompoundKey(symbol, type string, opened time.Time, ...) (*Option, error)
+```
+
+### Database Query Patterns
+```go
+// Always use prepared statements
+query := `UPDATE options SET exit_price = ?, closed = ? WHERE id = ?`
+_, err := s.db.Exec(query, exitPrice, time.Now(), optionID)
+
+// RETURNING clause for SQLite INSERT/UPDATE
+query := `INSERT INTO symbols (symbol, price) VALUES (?, ?) RETURNING symbol, price, created_at`
+err := s.db.QueryRow(query, symbol, price).Scan(&sym.Symbol, &sym.Price, &sym.CreatedAt)
+```
+
+### HTML Template Helpers
+```go
+// Custom template functions registered in server.go
+funcMap := template.FuncMap{
+    "groupByExpiration": groupPositionsByExpiration, // Groups options by expiration date
+    "add": func(a, b interface{}) interface{} { ... }, // Safe addition for mixed types
+}
+```
+
+### Wheel Strategy State Transitions
+```go
+// 1. Sell cash-secured put → Option record created (type="Put")
+// 2. Put assigned → LongPosition created, Treasury balance decreased
+// 3. Sell covered call → Option record created (type="Call")
+// 4. Call assigned → LongPosition closed, Treasury balance increased
+```
+
+## Important Context
+
+### Financial Domain Knowledge
+- **Option multiplier**: 1 contract = 100 shares (always multiply by 100 for cash calculations)
+- **Strike semantics**: Put assignment happens when stock price < strike; Call assignment when price > strike
+- **Premium collection**: Income earned upfront when selling options (both puts and calls)
+- **Collateral mechanics**: Treasury amounts dynamically adjust as options are assigned
+
+### Security Considerations
+- Never commit API keys; use `settings` table for Polygon.io key storage
+- Financial precision: Use `REAL` type in SQLite, not integers for monetary values
+- Input validation: All form inputs validated before database operations
+- SQL injection prevention: Always use prepared statements, never string concatenation
+
+### Project-Specific Quirks
+- Module name is `stonks` in `go.mod`, but project is called "Wheeler"
+- Database path resolution uses `./data/currentdb` file to track active database
+- CGO must be enabled for SQLite3 driver: `CGO_ENABLED=1 go build`
+- Port 8080 for development, 8077 for Docker (see `docker-compose.yml`)
+
+## Common Tasks
+
+### Adding New Domain Entity
+1. Create model struct in `internal/models/{entity}.go` with service pattern
+2. Add table schema to `internal/database/schema.sql`
+3. Implement CRUD methods: `Create`, `GetByID`, `Update`, `Delete`, `GetAll`
+4. Add handler in `internal/web/{entity}_handlers.go` with API endpoints
+5. Create HTML template in `internal/web/templates/{entity}.html`
+
+### Adding API Endpoint
+```go
+// In server.go
+func (s *Server) setupRoutes() {
+    http.HandleFunc("/api/entity/{id}", s.handleEntityAPI)
+}
+
+// Handler pattern (in handlers.go)
+func (s *Server) handleEntityAPI(w http.ResponseWriter, r *http.Request) {
+    switch r.Method {
+    case http.MethodGet: /* ... */
+    case http.MethodPut: /* ... */
+    case http.MethodDelete: /* ... */
+    }
+}
+```
+
+### Running Integration Tests
+```bash
+# Set API key via environment or settings table
+export POLYGON_API_KEY="your_key_here"
+go test -v ./internal/polygon/
+```
+
+## References
+- `CLAUDE.md`: Comprehensive development guidance (250+ lines)
+- `model.md`: Complete database schema specification
+- `README.md`: User-facing documentation and quick start
+- `internal/database/schema.sql`: Authoritative database structure

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,6 +27,16 @@ Services use **ID-based CRUD** operations (`GetByID`, `Update`, `Delete`) for we
 - No migration files; database setup uses `CREATE TABLE IF NOT EXISTS`
 - SQLite WAL mode with foreign keys enabled: `?_busy_timeout=10000&_journal_mode=WAL&_foreign_keys=on`
 
+### Market Data Providers (`internal/providers/`)
+- Defines a common interface and types for market data providers (quotes, aggregates, ticker metadata)
+- Application code depends on this abstraction rather than any specific vendor
+- New providers should implement this interface and be registered via the provider layer
+
+### Polygon Provider (`internal/polygon/`)
+- Default implementation of the market data provider interface using the Polygon.io REST API
+- `client.go`: HTTP client wrapper around Polygon.io endpoints
+- `service.go`: Business logic layer for fetching quotes, aggregates, and ticker details via the provider interface
+
 ### Web Layer (`internal/web/`)
 **Handler Organization**:
 - `server.go`: Server struct initialization, routing, template loading with custom functions

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,7 @@
 # Wheeler Development Instructions for AI Agents
 
 ## Project Context
-Wheeler is a Go web application for tracking options trading strategies (particularly "wheel strategy"), with SQLite persistence and Polygon.io market data integration. The core domain involves sophisticated financial tracking: cash-secured puts, covered calls, stock assignments, dividends, and Treasury collateral management.
+Wheeler is a Go web application for tracking options trading strategies (particularly the "wheel strategy"), with SQLite persistence and Polygon.io market data integration. The core domain involves sophisticated financial tracking: cash-secured puts, covered calls, stock assignments, dividends, and Treasury collateral management.
 
 ## Architecture Overview
 
@@ -32,10 +32,11 @@ Services use **ID-based CRUD** operations (`GetByID`, `Update`, `Delete`) for we
 - Application code depends on this abstraction rather than any specific vendor
 - New providers should implement this interface and be registered via the provider layer
 
+### Provider Workflows (`internal/providers/`)
+- `service.go`: Selects configured providers and performs provider-independent market-data workflows.
+
 ### Polygon Provider (`internal/polygon/`)
-- Default implementation of the market data provider interface using the Polygon.io REST API
-- `client.go`: HTTP client wrapper around Polygon.io endpoints
-- `service.go`: Business logic layer for fetching quotes, aggregates, and ticker details via the provider interface
+- `client.go`: HTTP client wrapper around Polygon.io endpoints.
 
 ### Web Layer (`internal/web/`)
 **Handler Organization**:
@@ -86,7 +87,7 @@ func (s *OptionService) GetByID(id int) (*Option, error)
 func (s *OptionService) Update(id int, updates map[string]interface{}) error
 
 // Compound key fallbacks (legacy compatibility)
-func (s *OptionService) GetByCompoundKey(symbol, type string, opened time.Time, ...) (*Option, error)
+func (s *OptionService) GetByCompoundKey(symbol, optionType string, opened time.Time, strike float64) (*Option, error)
 ```
 
 ### Database Query Patterns
@@ -175,4 +176,4 @@ go test -v ./internal/polygon/
 - `CLAUDE.md`: Comprehensive development guidance (250+ lines)
 - `model.md`: Complete database schema specification
 - `README.md`: User-facing documentation and quick start
-- `internal/database/schema.sql`: Authoritative database structure
+- `internal/database/schema.sql`: Base schema for new databases; pair schema changes with a timestamped migration

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,8 +23,8 @@ Services use **ID-based CRUD** operations (`GetByID`, `Update`, `Delete`) for we
 - **Unique constraints** prevent duplicate business records (e.g., same option opened twice)
 
 **Schema Management**:
-- `schema.sql` is the single source of truth (embedded via `//go:embed`)
-- No migration files; database setup uses `CREATE TABLE IF NOT EXISTS`
+- SQL migrations live in `internal/database/migrations/*.sql` and are embedded via `//go:embed`.
+- Migrations are the source of truth for schema changes; add new migrations for any schema update instead of modifying existing migrations or relying on ad-hoc `CREATE TABLE IF NOT EXISTS`.
 - SQLite WAL mode with foreign keys enabled: `?_busy_timeout=10000&_journal_mode=WAL&_foreign_keys=on`
 
 ### Market Data Providers (`internal/providers/`)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -141,10 +141,11 @@ funcMap := template.FuncMap{
 
 ### Adding New Domain Entity
 1. Create model struct in `internal/models/{entity}.go` with service pattern
-2. Add table schema to `internal/database/schema.sql`
-3. Implement CRUD methods: `Create`, `GetByID`, `Update`, `Delete`, `GetAll`
-4. Add handler in `internal/web/{entity}_handlers.go` with API endpoints
-5. Create HTML template in `internal/web/templates/{entity}.html`
+2. Update `internal/database/schema.sql` for newly created databases
+3. **Required:** add a new timestamped, embedded migration in `internal/database/migrations/` for existing databases; never modify an existing migration or rely on an ad-hoc `CREATE TABLE IF NOT EXISTS`
+4. Implement CRUD methods: `Create`, `GetByID`, `Update`, `Delete`, `GetAll`
+5. Add handler in `internal/web/{entity}_handlers.go` with API endpoints
+6. Create HTML template in `internal/web/templates/{entity}.html`
 
 ### Adding API Endpoint
 ```go

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -49,17 +49,6 @@ Services use **ID-based CRUD** operations (`GetByID`, `Update`, `Delete`) for we
 - Shared component: `_symbol_modal.html` for reusable symbol entry
 - Chart.js for interactive visualizations (scatter plots, pie charts with click navigation)
 
-### Market Data Providers (`internal/providers/`)
-- Defines a common interface and types for market data providers (quotes, aggregates, ticker metadata)
-- Application code depends on this abstraction rather than any specific vendor
-- New providers should implement this interface and be registered via the provider layer
-
-### Polygon Provider (`internal/polygon/`)
-- Default implementation of the market data provider interface using the Polygon.io REST API
-- `client.go`: HTTP client wrapper around Polygon.io endpoints
-- `service.go`: Business logic layer for fetching quotes, aggregates, and ticker details via the provider interface
-- API key stored in `settings` table, retrieved via `SettingService`
-
 ## Development Commands
 
 ### Quick Start

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -49,9 +49,15 @@ Services use **ID-based CRUD** operations (`GetByID`, `Update`, `Delete`) for we
 - Shared component: `_symbol_modal.html` for reusable symbol entry
 - Chart.js for interactive visualizations (scatter plots, pie charts with click navigation)
 
-### External Integration (`internal/polygon/`)
-- `client.go`: HTTP client wrapping Polygon.io REST API
-- `service.go`: Business logic layer for fetching quotes, aggregates, and ticker details
+### Market Data Providers (`internal/providers/`)
+- Defines a common interface and types for market data providers (quotes, aggregates, ticker metadata)
+- Application code depends on this abstraction rather than any specific vendor
+- New providers should implement this interface and be registered via the provider layer
+
+### Polygon Provider (`internal/polygon/`)
+- Default implementation of the market data provider interface using the Polygon.io REST API
+- `client.go`: HTTP client wrapper around Polygon.io endpoints
+- `service.go`: Business logic layer for fetching quotes, aggregates, and ticker details via the provider interface
 - API key stored in `settings` table, retrieved via `SettingService`
 
 ## Development Commands

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,43 @@
 .claude
+
+# Local data files
 data/
+
+# Local env/secret files
+.env
+.env.*
+
+# Build artifacts
+bin/
+dist/
+tmp/
+coverage/
+
+# Logs
+*.log
+
+# Editor/OS
+.vscode/
+.idea/
+.DS_Store
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+
+# End of https://www.toptal.com/developers/gitignore/api/go

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .claude
-./data/.
+data/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,7 @@ The modern web interface provides comprehensive portfolio tracking:
 - `/api/allocation-data` - Portfolio allocation data for charts
 - `/api/generate-test-data` - Test data generation for tutorials
 - `/api/settings` - Application settings management
-- `/api/polygon/*` - Polygon.io API integration endpoints
+- `/api/provider/*` - Market data provider endpoints (connection tests, price refresh, dividend sync)
 
 ## Financial Domain Context
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,7 +280,7 @@ wheeler/
 │       ├── position_handlers.go     # Position management handlers
 │       ├── treasury_handlers.go     # Treasury management handlers
 │       ├── import_handlers.go       # Import/backup/database handlers
-│       ├── polygon_handlers.go      # Polygon.io integration handlers
+│       ├── provider_handlers.go     # Market data provider integration handlers
 │       ├── settings_handlers.go     # Settings management handlers
 │       ├── utility_handlers.go      # Utility functions and helpers
 │       ├── types.go                 # Web data types and structures

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,8 @@ make test                         # Run all tests (requires CGO for SQLite)
 
 ### Testing
 - Unit tests alongside code files (`*_test.go`)
-- Integration tests in `test/` folder with consistent naming pattern
-- Integration tests require live Polygon.io API key: `internal/polygon/live_integration_test.go`
+- Provider unit tests live in `internal/providers/{provider_name}_test.go`
+- Live Polygon integration tests require an API key: `internal/polygon/live_integration_test.go`
 - Test databases automatically cleaned: `rm -f test_*.db`
 
 ## Dependencies
@@ -58,11 +58,11 @@ Services use **ID-based CRUD** operations (`GetByID`, `Update`, `Delete`) for we
 ### Database Design (`internal/database/`)
 **Hybrid Primary Key Strategy**:
 - **Transactional tables** use `INTEGER PRIMARY KEY AUTOINCREMENT` for easier HTTP operations: `options.id`, `long_positions.id`, `dividends.id`
-- **Reference tables** use natural keys: `symbols.symbol`, `treasuries.cuspid`, `settings.name`
+- **Reference tables** use natural keys: `symbols.symbol`, Treasury CUSIP (`treasuries.cuspid`, a legacy column name), `settings.name`
 - **Unique constraints** prevent duplicate business records (e.g., same option opened twice)
 
 **Schema Management**:
-- `schema.sql` is the single source of truth (embedded via `//go:embed`) and defines the base schema
+- `schema.sql` defines the embedded base schema for newly created databases
 - Incremental schema changes are managed via embedded SQL migrations in `internal/database/migrations/*.sql`, which are executed at startup
 - SQLite WAL mode with foreign keys enabled: `?_busy_timeout=10000&_journal_mode=WAL&_foreign_keys=on`
 
@@ -182,7 +182,7 @@ func (s *OptionService) GetByID(id int) (*Option, error)
 func (s *OptionService) Update(id int, updates map[string]interface{}) error
 
 // Compound key fallbacks (legacy compatibility)
-func (s *OptionService) GetByCompoundKey(symbol, type string, opened time.Time, ...) (*Option, error)
+func (s *OptionService) GetByCompoundKey(symbol, optionType string, opened time.Time, strike float64) (*Option, error)
 ```
 
 ### Database Query Patterns
@@ -321,9 +321,9 @@ The database schema follows modern best practices for web applications:
 - **Check Constraints**: Validate option types (`'Put'` or `'Call'`)
 
 ### Schema Migration
-- **`internal/database/schema.sql`**: Single source of truth for database structure
-- **No Migration Files**: Removed legacy migration files; schema.sql is authoritative
-- **Automatic Setup**: Database tables created via `CREATE TABLE IF NOT EXISTS`
+- **`internal/database/schema.sql`**: Base schema for newly created databases
+- **`internal/database/migrations/*.sql`**: Timestamped embedded migrations are the source of truth for schema changes in existing databases
+- **Required change process**: Update `schema.sql` and add a new migration; never edit an applied migration or rely on ad-hoc `CREATE TABLE IF NOT EXISTS`
 
 ## Database Management
 
@@ -351,9 +351,10 @@ To get started, use `go run main.go`, visit http://localhost:8080/help, switch t
 ### Adding New Domain Entity
 1. Create model struct in `internal/models/{entity}.go` with service pattern
 2. Add table schema to `internal/database/schema.sql`
-3. Implement CRUD methods: `Create`, `GetByID`, `Update`, `Delete`, `GetAll`
-4. Add handler in `internal/web/{entity}_handlers.go` with API endpoints
-5. Create HTML template in `internal/web/templates/{entity}.html`
+3. **Required:** Add a timestamped embedded migration in `internal/database/migrations/` for existing databases; never modify an existing migration or rely on an ad-hoc `CREATE TABLE IF NOT EXISTS`
+4. Implement CRUD methods: `Create`, `GetByID`, `Update`, `Delete`, `GetAll`
+5. Add handler in `internal/web/{entity}_handlers.go` with API endpoints
+6. Create HTML template in `internal/web/templates/{entity}.html`
 
 ### Adding API Endpoint
 ```go
@@ -393,7 +394,7 @@ go test -v ./internal/polygon/
    - `{PROVIDER_NAME}_API_KEY` - API key for the new provider
 5. Update `GetAPIKeyStatus()` to handle the new provider's API key validation
 6. Add rate limiting logic in `GetRateLimitDelay()` if needed
-7. Create tests in `test/providers_test.go` for the new provider
+7. Create unit tests in `internal/providers/{provider_name}_test.go` for the new provider
 
 Example provider structure:
 ```go
@@ -421,4 +422,4 @@ func (p *NewProvider) Name() string {
 - `CLAUDE.md`: AI agent development instructions
 - `model.md`: Complete database schema specification
 - `README.md`: User-facing documentation and quick start
-- `internal/database/schema.sql`: Authoritative database structure
+- `internal/database/schema.sql`: Base schema for new databases; pair schema changes with a timestamped migration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,36 +14,79 @@ The project contains one main application:
 
 ## Development Commands
 
-### Web Dashboard (Primary Application)
-- **Run web dashboard**: `go run main.go` (starts on http://localhost:8080)
-- **Build web dashboard**: `go build . && ./wheeler`
+### Quick Start
+```bash
+go run main.go                    # Start web server on :8080
+make build                        # Build to bin/wheeler with CGO enabled
+make test                         # Run all tests (requires CGO for SQLite)
+```
 
 ### Database Operations
-- **Load test data**: Use the Generate Test Data buttons in Help → Tutorial
-- **Multiple databases**: Create/switch databases via Admin → Database
-- **Database backups**: Manual backups via Admin → Database page
+- **Multiple databases**: Current DB tracked in `./data/currentdb` file
+- **Test data**: Click "Generate Test Data" in Help → Tutorial (loads `wheel_strategy_example.sql`)
+- **Backups**: Manual backup via Admin page saves to `./data/backups/`
+
+### Testing
+- Unit tests alongside code files (`*_test.go`)
+- Integration tests in `test/` folder with consistent naming pattern
+- Integration tests require live Polygon.io API key: `internal/polygon/live_integration_test.go`
+- Test databases automatically cleaned: `rm -f test_*.db`
 
 ## Dependencies
 
 - Go 1.19+ with modules support
-- SQLite3 (`github.com/mattn/go-sqlite3`)
-- No GTK dependencies required for web dashboard
-- Web technologies: HTML5, CSS3, JavaScript, Chart.js
+- SQLite3 (`github.com/mattn/go-sqlite3`) - requires CGO
+- Chart.js for interactive visualizations
+- Standard library: `database/sql`, `net/http`, `html/template`
+- No GTK or external UI framework dependencies for web dashboard
 
-## Architecture Notes
+## Architecture Overview
 
-Key architectural decisions and patterns:
+Wheeler follows a layered architecture with clear separation of concerns:
 
-- **Primary Stack**: Go + Web Frontend + SQLite database
-- **Data Models**: Symbols, options, long positions, dividends, treasuries (see model.md)
-- **Database Design**: 
-  - INTEGER PRIMARY KEY AUTOINCREMENT for transactional data (options, long_positions, dividends)
-  - Natural primary keys for reference data (symbols.symbol, treasuries.cuspid)
-  - UNIQUE indexes to prevent duplicate business records
-  - Foreign key relationships for data integrity
-- **Web Interface**: HTML templates with Chart.js visualizations and AJAX APIs
-- **Service Layer**: ID-based CRUD operations with compound key fallbacks for compatibility
-- **API Design**: RESTful endpoints using integer IDs for easier HTTP operations
+### Service Layer Pattern (`internal/models/`)
+Each domain entity has a dedicated service struct wrapping the `*sql.DB`:
+- **OptionService**: Manages Put/Call lifecycle with automatic commission calculation ($0.65/contract)
+- **LongPositionService**: Tracks stock holdings from put assignments to call assignments
+- **SymbolService**: Maintains stock metadata (price, dividend, P/E ratio)
+- **TreasuryService**: Handles collateral with dynamic balance adjustments
+- **DividendService**: Records dividend payments and yield calculations
+- **MetricService**: Aggregates portfolio performance and P&L calculations
+
+Services use **ID-based CRUD** operations (`GetByID`, `Update`, `Delete`) for web-friendly REST patterns. Compound key fallbacks exist for backward compatibility but are deprecated.
+
+### Database Design (`internal/database/`)
+**Hybrid Primary Key Strategy**:
+- **Transactional tables** use `INTEGER PRIMARY KEY AUTOINCREMENT` for easier HTTP operations: `options.id`, `long_positions.id`, `dividends.id`
+- **Reference tables** use natural keys: `symbols.symbol`, `treasuries.cuspid`, `settings.name`
+- **Unique constraints** prevent duplicate business records (e.g., same option opened twice)
+
+**Schema Management**:
+- `schema.sql` is the single source of truth (embedded via `//go:embed`)
+- No migration files; database setup uses `CREATE TABLE IF NOT EXISTS`
+- SQLite WAL mode with foreign keys enabled: `?_busy_timeout=10000&_journal_mode=WAL&_foreign_keys=on`
+
+### Market Data Providers (`internal/providers/`)
+- Defines a common interface and types for market data providers (quotes, aggregates, ticker metadata)
+- Application code depends on this abstraction rather than any specific vendor
+- New providers should implement this interface and be registered via the provider layer
+
+### Polygon Provider (`internal/polygon/`)
+- Default implementation of the market data provider interface using the Polygon.io REST API
+- `client.go`: HTTP client wrapper around Polygon.io endpoints
+- `service.go`: Business logic layer for fetching quotes, aggregates, and ticker details via the provider interface
+
+### Web Layer (`internal/web/`)
+**Handler Organization**:
+- `server.go`: Server struct initialization, routing, template loading with custom functions
+- `*_handlers.go`: Domain-specific handlers (dashboard, options, symbols, etc.)
+- `types.go`: Web-specific data structures for JSON API responses
+- `utility_handlers.go`: Shared helper functions
+
+**Template Pattern**:
+- HTML templates in `templates/` use Go templating with custom functions (`groupByExpiration`, `add`, `mul`)
+- Shared component: `_symbol_modal.html` for reusable symbol entry
+- Chart.js for interactive visualizations (scatter plots, pie charts with click navigation)
 
 ## Web Dashboard Features
 
@@ -116,11 +159,73 @@ Wheeler specializes in sophisticated options trading strategies:
 
 ## Security Considerations
 
-- Never commit API keys for market data providers
-- Validate all financial calculations with appropriate precision
-- Follow security best practices for handling financial data
-- Use prepared statements for SQL operations to prevent injection
-- Validate form inputs before database operations
+- Never commit API keys; use `settings` table for Polygon.io key storage
+- Financial precision: Use `REAL` type in SQLite, not integers for monetary values
+- Input validation: All form inputs validated before database operations
+- SQL injection prevention: Always use prepared statements, never string concatenation
+
+## Key Patterns & Conventions
+
+### Financial Calculations
+```go
+// Options commission is always $0.65 per contract
+const OptionCommissionPerContract = 0.65
+
+// P&L calculation includes commission deductions
+profit := (premium - exitPrice) * float64(contracts) * 100 - commission
+```
+
+### Service Method Signatures
+```go
+// ID-based operations (preferred)
+func (s *OptionService) GetByID(id int) (*Option, error)
+func (s *OptionService) Update(id int, updates map[string]interface{}) error
+
+// Compound key fallbacks (legacy compatibility)
+func (s *OptionService) GetByCompoundKey(symbol, type string, opened time.Time, ...) (*Option, error)
+```
+
+### Database Query Patterns
+```go
+// Always use prepared statements
+query := `UPDATE options SET exit_price = ?, closed = ? WHERE id = ?`
+_, err := s.db.Exec(query, exitPrice, time.Now(), optionID)
+
+// RETURNING clause for SQLite INSERT/UPDATE
+query := `INSERT INTO symbols (symbol, price) VALUES (?, ?) RETURNING symbol, price, created_at`
+err := s.db.QueryRow(query, symbol, price).Scan(&sym.Symbol, &sym.Price, &sym.CreatedAt)
+```
+
+### HTML Template Helpers
+```go
+// Custom template functions registered in server.go
+funcMap := template.FuncMap{
+    "groupByExpiration": groupPositionsByExpiration, // Groups options by expiration date
+    "add": func(a, b interface{}) interface{} { ... }, // Safe addition for mixed types
+}
+```
+
+### Wheel Strategy State Transitions
+```go
+// 1. Sell cash-secured put → Option record created (type="Put")
+// 2. Put assigned → LongPosition created, Treasury balance decreased
+// 3. Sell covered call → Option record created (type="Call")
+// 4. Call assigned → LongPosition closed, Treasury balance increased
+```
+
+## Important Context
+
+### Financial Domain Knowledge
+- **Option multiplier**: 1 contract = 100 shares (always multiply by 100 for cash calculations)
+- **Strike semantics**: Put assignment happens when stock price < strike; Call assignment when price > strike
+- **Premium collection**: Income earned upfront when selling options (both puts and calls)
+- **Collateral mechanics**: Treasury amounts dynamically adjust as options are assigned
+
+### Project-Specific Quirks
+- Module name is `stonks` in `go.mod`, but project is called "Wheeler"
+- Database path resolution uses `./data/currentdb` file to track active database
+- CGO must be enabled for SQLite3 driver: `CGO_ENABLED=1 go build`
+- Port 8080 for development, 8077 for Docker (see `docker-compose.yml`)
 
 ## Project Structure
 
@@ -240,3 +345,80 @@ Wheeler supports multiple SQLite databases for different portfolios or environme
 - **Data Reset**: Switch databases or delete test database to start fresh
 
 To get started, use `go run main.go`, visit http://localhost:8080/help, switch to the Tutorial tab, and click "Generate Test Data" to see a complete wheel strategy implementation.
+
+## Common Tasks
+
+### Adding New Domain Entity
+1. Create model struct in `internal/models/{entity}.go` with service pattern
+2. Add table schema to `internal/database/schema.sql`
+3. Implement CRUD methods: `Create`, `GetByID`, `Update`, `Delete`, `GetAll`
+4. Add handler in `internal/web/{entity}_handlers.go` with API endpoints
+5. Create HTML template in `internal/web/templates/{entity}.html`
+
+### Adding API Endpoint
+```go
+// In server.go
+func (s *Server) setupRoutes() {
+    http.HandleFunc("/api/entity/{id}", s.handleEntityAPI)
+}
+
+// Handler pattern (in handlers.go)
+func (s *Server) handleEntityAPI(w http.ResponseWriter, r *http.Request) {
+    switch r.Method {
+    case http.MethodGet: /* ... */
+    case http.MethodPut: /* ... */
+    case http.MethodDelete: /* ... */
+    }
+}
+```
+
+### Running Integration Tests
+```bash
+# Set API key via environment or settings table
+export POLYGON_API_KEY="your_key_here"
+go test -v ./internal/polygon/
+```
+
+### Adding a New Data Provider
+1. Create a new provider implementation in `internal/providers/{provider_name}.go`
+2. Implement the `Provider` interface with all required methods:
+   - `GetQuote(ctx, symbol)` - Retrieve current quote data
+   - `GetTickerDetails(ctx, symbol)` - Get detailed ticker information
+   - `GetDividends(ctx, symbol, limit)` - Fetch dividend history
+   - `ValidateConnection(ctx)` - Test provider connectivity
+   - `Name()` - Return provider name
+3. Update `getProvider()` in `internal/providers/service.go` to support the new provider type
+4. Add settings entries for the new provider:
+   - `DATA_PROVIDER_TYPE` - Set to your provider name (e.g., "alphavantage")
+   - `{PROVIDER_NAME}_API_KEY` - API key for the new provider
+5. Update `GetAPIKeyStatus()` to handle the new provider's API key validation
+6. Add rate limiting logic in `GetRateLimitDelay()` if needed
+7. Create tests in `test/providers_test.go` for the new provider
+
+Example provider structure:
+```go
+type NewProvider struct {
+    apiKey string
+    client *http.Client
+}
+
+func NewNewProvider(apiKey string) *NewProvider {
+    return &NewProvider{
+        apiKey: apiKey,
+        client: &http.Client{Timeout: 30 * time.Second},
+    }
+}
+
+func (p *NewProvider) Name() string {
+    return "NewProvider"
+}
+
+// Implement remaining Provider interface methods...
+```
+
+## References
+- `.github/copilot-instructions.md`: AI agent development instructions
+- `CLAUDE.md`: AI agent development instructions
+- `model.md`: Complete database schema specification
+- `README.md`: User-facing documentation and quick start
+- `internal/database/schema.sql`: Authoritative database structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,10 +71,12 @@ Services use **ID-based CRUD** operations (`GetByID`, `Update`, `Delete`) for we
 - Application code depends on this abstraction rather than any specific vendor
 - New providers should implement this interface and be registered via the provider layer
 
-### Polygon Provider (`internal/polygon/`)
-- Default implementation of the market data provider interface using the Polygon.io REST API
+### Polygon Provider (`internal/providers/`)
+- `polygon.go`: Polygon implementation of the market data provider interface
+- `service.go`: Provider selection and provider-independent market-data workflows
+
+### Polygon Client (`internal/polygon/`)
 - `client.go`: HTTP client wrapper around Polygon.io endpoints
-- `service.go`: Business logic layer for fetching quotes, aggregates, and ticker details via the provider interface
 
 ### Web Layer (`internal/web/`)
 **Handler Organization**:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,8 +62,8 @@ Services use **ID-based CRUD** operations (`GetByID`, `Update`, `Delete`) for we
 - **Unique constraints** prevent duplicate business records (e.g., same option opened twice)
 
 **Schema Management**:
-- `schema.sql` is the single source of truth (embedded via `//go:embed`)
-- No migration files; database setup uses `CREATE TABLE IF NOT EXISTS`
+- `schema.sql` is the single source of truth (embedded via `//go:embed`) and defines the base schema
+- Incremental schema changes are managed via embedded SQL migrations in `internal/database/migrations/*.sql`, which are executed at startup
 - SQLite WAL mode with foreign keys enabled: `?_busy_timeout=10000&_journal_mode=WAL&_foreign_keys=on`
 
 ### Market Data Providers (`internal/providers/`)

--- a/README.md
+++ b/README.md
@@ -58,9 +58,11 @@ The Database view manages the Wheeler datastore. SQLite is used and it's a singl
 
 ![Database](./screenshots/database.png)
 
-### Polygon
+### Market Data Providers
 
-The Polygon view allows configuration of Polygon.io API and sync'ing of data. The free tier is used to get current price and other data.
+The Market Data view configures the live-data source per Wheeler database. New symbols use the canonical `MARKET:TICKER` key, such as `BVMF:PETR4`. Polygon.io requires an API key; Google Finance supports prices/details; Yahoo Finance (yfinance-compatible HTTP provider) requires no API key and also supports dividend history.
+
+Wheeler currently supports NASDAQ, NYSE, NYSE Arca, and B3 (`BVMF`). It resolves each canonical key to the provider format: Google Finance receives `TICKER:MARKET`, while Yahoo Finance receives a bare US ticker or the B3 `.SA` suffix. Existing bare tickers are historical records and must be manually qualified before provider updates.
 
 ![Polygon](./screenshots/polygon.png)
 
@@ -139,7 +141,7 @@ Edit `docker-compose.yml` to customize:
 
 - **Port**: Change `8077:8080` to use a different external port
 - **Volume**: Change `./data:/app/data` to your preferred data path
-- **Environment**: Uncomment and set `POLYGON_API_KEY` for market data
+- **Market data**: Configure the provider in **Admin → Market Data** after starting Wheeler. Polygon.io requires `POLYGON_API_KEY`; Yahoo Finance requires no credential. The legacy `GOOGLE_FINANCE_EXCHANGE` setting is no longer used for new symbols.
 
 ### Stopping Wheeler
 
@@ -177,6 +179,12 @@ Wheeler provides comprehensive RESTful APIs:
 - `GET/POST/PUT/DELETE /api/treasuries/{cuspid}` - Treasury operations
 - `GET /api/allocation-data` - Portfolio allocation data for charts
 - `POST /api/generate-test-data` - Test data generation for tutorials
+- `GET/POST /api/settings`, `GET/PUT/DELETE /api/settings/{name}` - Per-database application settings
+- `PUT /api/provider/configuration` - Atomically select and configure Polygon, Google Finance, or Yahoo Finance
+- `GET /api/provider/status`, `POST /api/provider/test` - Provider configuration and connectivity status
+- `POST /api/provider/update-prices` - Refresh prices (`{"all":true}` or `{"symbols":["NASDAQ:AAPL"]}`; requests process at most 20 symbols)
+- `GET /api/provider/symbol-info/{symbol}` - Fetch provider details; Google accepts `EXCHANGE:TICKER`, such as `NASDAQ:AAPL`
+- `POST /api/provider/fetch-dividends` - Fetch dividend histories when supported by the selected provider
 
 ## Project Structure
 
@@ -245,7 +253,7 @@ wheeler/
 │       │   ├── help.html            # Tabbed help system
 │       │   ├── backup.html          # Database management
 │       │   ├── import.html          # CSV import tools
-│       │   └── settings.html        # Polygon.io configuration
+│       │   └── settings.html        # Market-data provider configuration
 │       └── static/                  # Static web assets
 │           ├── assets/              # Static asset files
 │           ├── css/

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Wheeler provides comprehensive RESTful APIs:
 - `PUT /api/provider/configuration` - Atomically select and configure Polygon, Google Finance, or Yahoo Finance
 - `GET /api/provider/status`, `POST /api/provider/test` - Provider configuration and connectivity status
 - `POST /api/provider/update-prices` - Refresh prices (`{"all":true}` or `{"symbols":["NASDAQ:AAPL"]}`; requests process at most 20 symbols)
-- `GET /api/provider/symbol-info/{symbol}` - Fetch provider details; Google accepts `EXCHANGE:TICKER`, such as `NASDAQ:AAPL`
+- `GET /api/provider/symbol-info/{symbol}` - Fetch provider details using the canonical `MARKET:TICKER` key, such as `NASDAQ:AAPL`; the provider layer performs provider-specific conversion
 - `POST /api/provider/fetch-dividends` - Fetch dividend histories when supported by the selected provider
 
 ## Project Structure

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ wheeler/
 │       ├── position_handlers.go     # Position management handlers
 │       ├── treasury_handlers.go     # Treasury management handlers
 │       ├── import_handlers.go       # Import/backup/database handlers
-│       ├── polygon_handlers.go      # Polygon.io integration handlers
+│       ├── provider_handlers.go     # Market data provider integration handlers
 │       ├── settings_handlers.go     # Settings management handlers
 │       ├── utility_handlers.go      # Utility functions
 │       ├── types.go                 # Web data types and structures

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,4 +15,5 @@ services:
     restart: unless-stopped
     # Optional: uncomment to set environment variables
     # environment:
-    #   - POLYGON_API_KEY=your_api_key_here
+    # Configure a provider in Admin -> Market Data after startup.
+    # Polygon API keys are stored per Wheeler database.

--- a/internal/database/migration_test.go
+++ b/internal/database/migration_test.go
@@ -37,6 +37,24 @@ func TestMigrationSystem(t *testing.T) {
 		}
 	})
 
+	t.Run("provider settings migration applied", func(t *testing.T) {
+		var count int
+		err := db.QueryRow("SELECT COUNT(*) FROM schema_migrations WHERE version = '20260822220000_add_provider_settings'").Scan(&count)
+		if err != nil {
+			t.Fatalf("Failed to query provider settings migration: %v", err)
+		}
+		if count != 1 {
+			t.Errorf("Expected provider settings migration to be applied, got count=%d", count)
+		}
+
+		for _, name := range []string{"DATA_PROVIDER_TYPE", "GOOGLE_FINANCE_EXCHANGE"} {
+			var value string
+			if err := db.QueryRow("SELECT value FROM settings WHERE name = ?", name).Scan(&value); err != nil {
+				t.Errorf("Expected setting %s to exist: %v", name, err)
+			}
+		}
+	})
+
 	t.Run("all expected tables exist", func(t *testing.T) {
 		expectedTables := []string{
 			"schema_migrations",
@@ -114,8 +132,8 @@ func TestMigrationSystem(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to query schema_migrations: %v", err)
 		}
-		if count != 1 {
-			t.Errorf("Expected only 1 migration record after re-running migrations, got %d", count)
+		if count != 2 {
+			t.Errorf("Expected 2 migration records after re-running migrations, got %d", count)
 		}
 	})
 }

--- a/internal/database/migration_test.go
+++ b/internal/database/migration_test.go
@@ -55,6 +55,14 @@ func TestMigrationSystem(t *testing.T) {
 		}
 	})
 
+	t.Run("legacy Google exchange migration applied", func(t *testing.T) {
+		var count int
+		err := db.QueryRow("SELECT COUNT(*) FROM schema_migrations WHERE version = '20260823211500_mark_google_exchange_legacy'").Scan(&count)
+		if err != nil || count != 1 {
+			t.Fatalf("expected legacy Google exchange migration, count=%d err=%v", count, err)
+		}
+	})
+
 	t.Run("all expected tables exist", func(t *testing.T) {
 		expectedTables := []string{
 			"schema_migrations",
@@ -132,8 +140,8 @@ func TestMigrationSystem(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to query schema_migrations: %v", err)
 		}
-		if count != 2 {
-			t.Errorf("Expected 2 migration records after re-running migrations, got %d", count)
+		if count != 3 {
+			t.Errorf("Expected 3 migration records after re-running migrations, got %d", count)
 		}
 	})
 }

--- a/internal/database/migrations/20260822220000_add_provider_settings.sql
+++ b/internal/database/migrations/20260822220000_add_provider_settings.sql
@@ -1,0 +1,9 @@
+-- Add default provider settings to databases created before provider support.
+INSERT OR IGNORE INTO settings (name, value, description)
+VALUES ('DATA_PROVIDER_TYPE', 'polygon', 'Active market data provider: polygon, google_finance (google/googlefinance), or yfinance (yahoo/yahoo_finance)');
+
+INSERT OR IGNORE INTO settings (name, value, description)
+VALUES ('GOOGLE_FINANCE_EXCHANGE', 'NASDAQ', 'Default exchange for Google Finance symbols');
+
+INSERT OR IGNORE INTO schema_migrations (version)
+VALUES ('20260822220000_add_provider_settings');

--- a/internal/database/migrations/20260823211500_mark_google_exchange_legacy.sql
+++ b/internal/database/migrations/20260823211500_mark_google_exchange_legacy.sql
@@ -1,0 +1,9 @@
+-- Markets are now selected per symbol; retain this setting only for legacy
+-- compatibility and make that clear to existing databases.
+UPDATE settings
+SET description = 'Legacy default exchange; new symbols select their market individually',
+    updated_at = CURRENT_TIMESTAMP
+WHERE name = 'GOOGLE_FINANCE_EXCHANGE';
+
+INSERT OR IGNORE INTO schema_migrations (version)
+VALUES ('20260823211500_mark_google_exchange_legacy');

--- a/internal/database/schema.sql
+++ b/internal/database/schema.sql
@@ -78,8 +78,15 @@ CREATE TABLE IF NOT EXISTS metrics (
 );
 
 -- Insert default POLYGON_API_KEY setting
+INSERT OR IGNORE INTO settings (name, value, description)
+VALUES ('DATA_PROVIDER_TYPE', 'polygon', 'Active market data provider: polygon, google_finance (google/googlefinance), or yfinance (yahoo/yahoo_finance)');
+
 INSERT OR IGNORE INTO settings (name, value, description) 
 VALUES ('POLYGON_API_KEY', '', 'API key for Polygon.io stock market data integration');
+
+INSERT OR IGNORE INTO settings (name, value, description)
+VALUES ('GOOGLE_FINANCE_EXCHANGE', 'NASDAQ', 'Default exchange for Google Finance symbols');
+
 
 -- Indexes for performance
 -- Note: Primary key columns automatically have indexes, so we don't need explicit indexes for:

--- a/internal/database/schema.sql
+++ b/internal/database/schema.sql
@@ -85,7 +85,7 @@ INSERT OR IGNORE INTO settings (name, value, description)
 VALUES ('POLYGON_API_KEY', '', 'API key for Polygon.io stock market data integration');
 
 INSERT OR IGNORE INTO settings (name, value, description)
-VALUES ('GOOGLE_FINANCE_EXCHANGE', 'NASDAQ', 'Default exchange for Google Finance symbols');
+VALUES ('GOOGLE_FINANCE_EXCHANGE', 'NASDAQ', 'Legacy default exchange; new symbols select their market individually');
 
 
 -- Indexes for performance

--- a/internal/markets/markets.go
+++ b/internal/markets/markets.go
@@ -1,0 +1,100 @@
+// Package markets defines Wheeler's supported market identifiers and their
+// provider-specific ticker formats.
+package markets
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const (
+	NASDAQ   = "NASDAQ"
+	NYSE     = "NYSE"
+	NYSEARCA = "NYSEARCA"
+	BVMF     = "BVMF"
+)
+
+var tickerPattern = regexp.MustCompile(`^[A-Z0-9.\-]{1,10}$`)
+
+// Definition describes a market supported by Wheeler. ID is also the Google
+// Finance exchange code and the first part of Wheeler's canonical symbol key.
+type Definition struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"display_name"`
+	YahooSuffix string `json:"-"`
+	Polygon     bool   `json:"polygon_supported"`
+}
+
+var definitions = map[string]Definition{
+	NASDAQ:   {ID: NASDAQ, DisplayName: "NASDAQ", Polygon: true},
+	NYSE:     {ID: NYSE, DisplayName: "NYSE", Polygon: true},
+	NYSEARCA: {ID: NYSEARCA, DisplayName: "NYSE Arca", Polygon: true},
+	BVMF:     {ID: BVMF, DisplayName: "B3 (Brasil)", YahooSuffix: ".SA"},
+}
+
+// Instrument is Wheeler's provider-neutral instrument identity.
+type Instrument struct {
+	Market string
+	Ticker string
+}
+
+func (i Instrument) Key() string { return i.Market + ":" + i.Ticker }
+
+// Definitions returns the supported markets in stable UI order.
+func Definitions() []Definition {
+	return []Definition{definitions[NASDAQ], definitions[NYSE], definitions[NYSEARCA], definitions[BVMF]}
+}
+
+func Get(id string) (Definition, bool) {
+	definition, ok := definitions[strings.ToUpper(strings.TrimSpace(id))]
+	return definition, ok
+}
+
+func New(market, ticker string) (Instrument, error) {
+	definition, ok := Get(market)
+	if !ok {
+		return Instrument{}, fmt.Errorf("unsupported market: %q", strings.TrimSpace(market))
+	}
+	ticker = strings.ToUpper(strings.TrimSpace(ticker))
+	if !tickerPattern.MatchString(ticker) {
+		return Instrument{}, fmt.Errorf("invalid ticker: %q", ticker)
+	}
+	return Instrument{Market: definition.ID, Ticker: ticker}, nil
+}
+
+// Parse accepts only the canonical MARKET:TICKER key. Bare legacy tickers are
+// intentionally rejected so callers cannot issue ambiguous provider requests.
+func Parse(key string) (Instrument, error) {
+	parts := strings.Split(strings.ToUpper(strings.TrimSpace(key)), ":")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return Instrument{}, fmt.Errorf("market selection required; use MARKET:TICKER")
+	}
+	return New(parts[0], parts[1])
+}
+
+func IsLegacyKey(key string) bool {
+	return !strings.Contains(strings.TrimSpace(key), ":")
+}
+
+// ProviderSymbol converts a canonical key to the external ticker expected by
+// a provider. providerType uses Wheeler's canonical provider identifiers.
+func ProviderSymbol(providerType string, instrument Instrument) (string, error) {
+	definition, ok := Get(instrument.Market)
+	if !ok {
+		return "", fmt.Errorf("unsupported market: %q", instrument.Market)
+	}
+	switch providerType {
+	case "google_finance":
+		return instrument.Ticker + ":" + definition.ID, nil
+	case "yfinance":
+		return instrument.Ticker + definition.YahooSuffix, nil
+	case "polygon":
+		if !definition.Polygon {
+			return "", fmt.Errorf("Polygon.io does not support market %s", definition.ID)
+		}
+		return instrument.Ticker, nil
+	default:
+		return "", fmt.Errorf("unsupported data provider type: %s", providerType)
+	}
+}

--- a/internal/markets/markets_test.go
+++ b/internal/markets/markets_test.go
@@ -1,0 +1,40 @@
+package markets
+
+import "testing"
+
+func TestProviderSymbols(t *testing.T) {
+	tests := []struct {
+		key, provider, want string
+	}{
+		{"NASDAQ:AAPL", "google_finance", "AAPL:NASDAQ"},
+		{"NASDAQ:AAPL", "yfinance", "AAPL"},
+		{"NYSE:IBM", "google_finance", "IBM:NYSE"},
+		{"NYSE:IBM", "yfinance", "IBM"},
+		{"NYSEARCA:SPY", "google_finance", "SPY:NYSEARCA"},
+		{"NYSEARCA:SPY", "yfinance", "SPY"},
+		{"BVMF:PETR4", "google_finance", "PETR4:BVMF"},
+		{"BVMF:PETR4", "yfinance", "PETR4.SA"},
+	}
+	for _, tt := range tests {
+		instrument, err := Parse(tt.key)
+		if err != nil {
+			t.Fatalf("Parse(%q): %v", tt.key, err)
+		}
+		if got, err := ProviderSymbol(tt.provider, instrument); err != nil || got != tt.want {
+			t.Errorf("ProviderSymbol(%s, %s) = %q, %v; want %q", tt.provider, tt.key, got, err, tt.want)
+		}
+	}
+}
+
+func TestRejectsLegacyAndUnsupportedSymbols(t *testing.T) {
+	if _, err := Parse("AAPL"); err == nil {
+		t.Fatal("expected legacy key to be rejected")
+	}
+	if _, err := Parse("LSE:VOD"); err == nil {
+		t.Fatal("expected unsupported market to be rejected")
+	}
+	instrument, _ := Parse("BVMF:PETR4")
+	if _, err := ProviderSymbol("polygon", instrument); err == nil {
+		t.Fatal("expected BVMF to be rejected for Polygon")
+	}
+}

--- a/internal/models/metric.go
+++ b/internal/models/metric.go
@@ -47,11 +47,19 @@ type Metric struct {
 }
 
 type MetricService struct {
-	db *sql.DB
+	db  *sql.DB
+	now func() time.Time
 }
 
 func NewMetricService(db *sql.DB) *MetricService {
-	return &MetricService{db: db}
+	return &MetricService{db: db, now: time.Now}
+}
+
+func (ms *MetricService) currentTime() time.Time {
+	if ms.now == nil {
+		return time.Now()
+	}
+	return ms.now()
 }
 
 func (ms *MetricService) Create(metricType MetricType, value float64) (*Metric, error) {
@@ -186,7 +194,7 @@ func (ms *MetricService) ComprehensiveSnapshot(days int) error {
 	}
 
 	// Get today's date and calculate the start date
-	today := time.Now()
+	today := ms.currentTime()
 
 	// For each day in the range, calculate and upsert all metrics
 	for i := 0; i < days; i++ {
@@ -284,7 +292,7 @@ func (ms *MetricService) calculateTreasuryValueForDate(date time.Time) (float64,
 	//   but included in historical dates before they were sold (assuming sold at maturity for historical data)
 
 	// For current date calculations, only include unsold treasuries
-	if date.Format("2006-01-02") == time.Now().Format("2006-01-02") {
+	if date.Format("2006-01-02") == ms.currentTime().Format("2006-01-02") {
 		query := `
 			SELECT COALESCE(SUM(amount), 0) as total_value
 			FROM treasuries 

--- a/internal/models/metric_test.go
+++ b/internal/models/metric_test.go
@@ -23,10 +23,13 @@ func TestMetricService_ComprehensiveSnapshot(t *testing.T) {
 	positionService := NewLongPositionService(testDB.DB)
 	optionService := NewOptionService(testDB.DB)
 
-	// Create test treasury data with specific dates spanning several months
-	testDate1 := time.Now().AddDate(0, -4, 0) // 4 months ago
-	testDate2 := time.Now().AddDate(0, -2, 0) // 2 months ago  
-	testDate3 := time.Now().AddDate(0, 0, -30) // 30 days ago
+	// Use local midday to keep the fixture on the intended SQLite calendar date
+	// after timezone normalization.
+	now := time.Now()
+	baseDate := time.Date(now.Year(), now.Month(), now.Day(), 12, 0, 0, 0, now.Location())
+	testDate1 := baseDate.AddDate(0, -4, 0)  // 4 months ago
+	testDate2 := baseDate.AddDate(0, -2, 0)  // 2 months ago
+	testDate3 := baseDate.AddDate(0, 0, -30) // 30 days ago
 
 	// Treasury 1: Active for all 3 dates (purchased before testDate1)
 	maturityDate1 := testDate1.AddDate(0, 3, 0) // 3 months later
@@ -92,7 +95,7 @@ func TestMetricService_ComprehensiveSnapshot(t *testing.T) {
 
 	// Create test options with specific dates
 	expirationDate := testDate3.AddDate(0, 1, 0) // 1 month after testDate3
-	
+
 	// Put option 1: AAPL opened before testDate1, still active (strike $140, 2 contracts, exposure = 140 * 2 * 100 = $28000)
 	_, err = optionService.Create("AAPL", "Put", testDate1.AddDate(0, 0, -1), 140.0, expirationDate, 3.50, 2)
 	if err != nil {

--- a/internal/models/metric_test.go
+++ b/internal/models/metric_test.go
@@ -23,10 +23,9 @@ func TestMetricService_ComprehensiveSnapshot(t *testing.T) {
 	positionService := NewLongPositionService(testDB.DB)
 	optionService := NewOptionService(testDB.DB)
 
-	// Use local midday to keep the fixture on the intended SQLite calendar date
-	// after timezone normalization.
-	now := time.Now()
-	baseDate := time.Date(now.Year(), now.Month(), now.Day(), 12, 0, 0, 0, now.Location())
+	// Use a fixed midday UTC reference to make SQLite date comparisons fully deterministic.
+	baseDate := time.Date(2024, 5, 15, 12, 0, 0, 0, time.UTC)
+	metricService.now = func() time.Time { return baseDate }
 	testDate1 := baseDate.AddDate(0, -4, 0)  // 4 months ago
 	testDate2 := baseDate.AddDate(0, -2, 0)  // 2 months ago
 	testDate3 := baseDate.AddDate(0, 0, -30) // 30 days ago
@@ -60,30 +59,30 @@ func TestMetricService_ComprehensiveSnapshot(t *testing.T) {
 	}
 
 	// Create symbols for long positions
-	_, err = symbolService.Create("AAPL")
+	_, err = symbolService.Create("NASDAQ:AAPL")
 	if err != nil {
 		t.Fatalf("Failed to create AAPL symbol: %v", err)
 	}
-	_, err = symbolService.Create("TSLA")
+	_, err = symbolService.Create("NASDAQ:TSLA")
 	if err != nil {
 		t.Fatalf("Failed to create TSLA symbol: %v", err)
 	}
 
 	// Create test long positions with specific dates
 	// Position 1: AAPL opened before testDate1, still active (100 shares * $150 = $15000)
-	_, err = positionService.Create("AAPL", testDate1.AddDate(0, 0, -1), 100, 150.0)
+	_, err = positionService.Create("NASDAQ:AAPL", testDate1.AddDate(0, 0, -1), 100, 150.0)
 	if err != nil {
 		t.Fatalf("Failed to create AAPL position: %v", err)
 	}
 
 	// Position 2: TSLA opened on testDate2, still active (50 shares * $250 = $12500)
-	_, err = positionService.Create("TSLA", testDate2, 50, 250.0)
+	_, err = positionService.Create("NASDAQ:TSLA", testDate2, 50, 250.0)
 	if err != nil {
 		t.Fatalf("Failed to create TSLA position: %v", err)
 	}
 
 	// Position 3: AAPL opened before testDate1, closed on testDate2 (25 shares * $150 = $3750)
-	closedPosition, err := positionService.Create("AAPL", testDate1.AddDate(0, 0, -2), 25, 150.0)
+	closedPosition, err := positionService.Create("NASDAQ:AAPL", testDate1.AddDate(0, 0, -2), 25, 150.0)
 	if err != nil {
 		t.Fatalf("Failed to create closed AAPL position: %v", err)
 	}
@@ -97,19 +96,19 @@ func TestMetricService_ComprehensiveSnapshot(t *testing.T) {
 	expirationDate := testDate3.AddDate(0, 1, 0) // 1 month after testDate3
 
 	// Put option 1: AAPL opened before testDate1, still active (strike $140, 2 contracts, exposure = 140 * 2 * 100 = $28000)
-	_, err = optionService.Create("AAPL", "Put", testDate1.AddDate(0, 0, -1), 140.0, expirationDate, 3.50, 2)
+	_, err = optionService.Create("NASDAQ:AAPL", "Put", testDate1.AddDate(0, 0, -1), 140.0, expirationDate, 3.50, 2)
 	if err != nil {
 		t.Fatalf("Failed to create AAPL put option: %v", err)
 	}
 
 	// Put option 2: TSLA opened on testDate2, still active (strike $230, 1 contract, exposure = 230 * 1 * 100 = $23000)
-	_, err = optionService.Create("TSLA", "Put", testDate2, 230.0, expirationDate, 5.00, 1)
+	_, err = optionService.Create("NASDAQ:TSLA", "Put", testDate2, 230.0, expirationDate, 5.00, 1)
 	if err != nil {
 		t.Fatalf("Failed to create TSLA put option: %v", err)
 	}
 
 	// Put option 3: AAPL opened before testDate1, closed on testDate2 (strike $135, 1 contract, exposure = 135 * 1 * 100 = $13500)
-	closedPutOption, err := optionService.Create("AAPL", "Put", testDate1.AddDate(0, 0, -2), 135.0, expirationDate, 2.75, 1)
+	closedPutOption, err := optionService.Create("NASDAQ:AAPL", "Put", testDate1.AddDate(0, 0, -2), 135.0, expirationDate, 2.75, 1)
 	if err != nil {
 		t.Fatalf("Failed to create closed AAPL put option: %v", err)
 	}
@@ -121,19 +120,19 @@ func TestMetricService_ComprehensiveSnapshot(t *testing.T) {
 
 	// Create test call options with specific dates
 	// Call option 1: AAPL opened before testDate1, still active (premium $2.25, 3 contracts, premium = 2.25 * 3 * 100 = $675)
-	_, err = optionService.Create("AAPL", "Call", testDate1.AddDate(0, 0, -1), 160.0, expirationDate, 2.25, 3)
+	_, err = optionService.Create("NASDAQ:AAPL", "Call", testDate1.AddDate(0, 0, -1), 160.0, expirationDate, 2.25, 3)
 	if err != nil {
 		t.Fatalf("Failed to create AAPL call option: %v", err)
 	}
 
 	// Call option 2: TSLA opened on testDate2, still active (premium $4.75, 2 contracts, premium = 4.75 * 2 * 100 = $950)
-	_, err = optionService.Create("TSLA", "Call", testDate2, 270.0, expirationDate, 4.75, 2)
+	_, err = optionService.Create("NASDAQ:TSLA", "Call", testDate2, 270.0, expirationDate, 4.75, 2)
 	if err != nil {
 		t.Fatalf("Failed to create TSLA call option: %v", err)
 	}
 
 	// Call option 3: AAPL opened before testDate1, closed on testDate2 (premium $1.85, 1 contract, premium = 1.85 * 1 * 100 = $185)
-	closedCallOption, err := optionService.Create("AAPL", "Call", testDate1.AddDate(0, 0, -2), 155.0, expirationDate, 1.85, 1)
+	closedCallOption, err := optionService.Create("NASDAQ:AAPL", "Call", testDate1.AddDate(0, 0, -2), 155.0, expirationDate, 1.85, 1)
 	if err != nil {
 		t.Fatalf("Failed to create closed AAPL call option: %v", err)
 	}

--- a/internal/models/symbol.go
+++ b/internal/models/symbol.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"math"
+	"stonks/internal/markets"
 	"strings"
 	"time"
 )
@@ -307,19 +308,75 @@ func NewSymbolService(db *sql.DB) *SymbolService {
 }
 
 func (s *SymbolService) Create(symbol string) (*Symbol, error) {
-	symbol = strings.TrimSpace(strings.ToUpper(symbol))
-	if symbol == "" {
-		return nil, fmt.Errorf("symbol cannot be empty")
+	instrument, err := markets.Parse(symbol)
+	if err != nil {
+		return nil, err
 	}
+	symbol = instrument.Key()
 
 	query := `INSERT INTO symbols (symbol) VALUES (?) RETURNING symbol, price, dividend, ex_dividend_date, pe_ratio, created_at, updated_at`
 	var sym Symbol
-	err := s.db.QueryRow(query, symbol).Scan(&sym.Symbol, &sym.Price, &sym.Dividend, &sym.ExDividendDate, &sym.PERatio, &sym.CreatedAt, &sym.UpdatedAt)
+	err = s.db.QueryRow(query, symbol).Scan(&sym.Symbol, &sym.Price, &sym.Dividend, &sym.ExDividendDate, &sym.PERatio, &sym.CreatedAt, &sym.UpdatedAt)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create symbol: %w", err)
 	}
 
 	return &sym, nil
+}
+
+// QualifyLegacySymbol replaces a bare legacy ticker with a canonical
+// MARKET:TICKER key and moves every dependent record in one transaction.
+func (s *SymbolService) QualifyLegacySymbol(legacySymbol, market string) (*Symbol, error) {
+	legacySymbol = strings.ToUpper(strings.TrimSpace(legacySymbol))
+	if !markets.IsLegacyKey(legacySymbol) {
+		return nil, fmt.Errorf("symbol %q is already market-qualified", legacySymbol)
+	}
+	instrument, err := markets.New(market, legacySymbol)
+	if err != nil {
+		return nil, err
+	}
+	canonicalSymbol := instrument.Key()
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("start symbol qualification transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	var count int
+	if err := tx.QueryRow(`SELECT COUNT(*) FROM symbols WHERE symbol = ?`, legacySymbol).Scan(&count); err != nil {
+		return nil, fmt.Errorf("find legacy symbol: %w", err)
+	}
+	if count == 0 {
+		return nil, fmt.Errorf("symbol not found")
+	}
+	if err := tx.QueryRow(`SELECT COUNT(*) FROM symbols WHERE symbol = ?`, canonicalSymbol).Scan(&count); err != nil {
+		return nil, fmt.Errorf("find canonical symbol: %w", err)
+	}
+	if count > 0 {
+		return nil, fmt.Errorf("symbol %s already exists", canonicalSymbol)
+	}
+
+	if _, err := tx.Exec(`INSERT INTO symbols (symbol, price, dividend, ex_dividend_date, pe_ratio, created_at, updated_at)
+		SELECT ?, price, dividend, ex_dividend_date, pe_ratio, created_at, updated_at FROM symbols WHERE symbol = ?`, canonicalSymbol, legacySymbol); err != nil {
+		return nil, fmt.Errorf("create canonical symbol: %w", err)
+	}
+	for table, query := range map[string]string{
+		"options":        `UPDATE options SET symbol = ? WHERE symbol = ?`,
+		"long_positions": `UPDATE long_positions SET symbol = ? WHERE symbol = ?`,
+		"dividends":      `UPDATE dividends SET symbol = ? WHERE symbol = ?`,
+	} {
+		if _, err := tx.Exec(query, canonicalSymbol, legacySymbol); err != nil {
+			return nil, fmt.Errorf("move %s records: %w", table, err)
+		}
+	}
+	if _, err := tx.Exec(`DELETE FROM symbols WHERE symbol = ?`, legacySymbol); err != nil {
+		return nil, fmt.Errorf("delete legacy symbol: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit symbol qualification: %w", err)
+	}
+	return s.GetBySymbol(canonicalSymbol)
 }
 
 func (s *SymbolService) GetBySymbol(symbol string) (*Symbol, error) {

--- a/internal/models/symbol_test.go
+++ b/internal/models/symbol_test.go
@@ -1,0 +1,65 @@
+package models
+
+import (
+	"path/filepath"
+	"stonks/internal/database"
+	"testing"
+	"time"
+)
+
+func TestSymbolServiceQualifyLegacySymbolMovesDependencies(t *testing.T) {
+	db, err := database.NewDB(filepath.Join(t.TempDir(), "symbols.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	if _, err := db.DB.Exec(`INSERT INTO symbols (symbol, price) VALUES ('PETR4', 40.50)`); err != nil {
+		t.Fatal(err)
+	}
+	optionService := NewOptionService(db.DB)
+	positionService := NewLongPositionService(db.DB)
+	dividendService := NewDividendService(db.DB)
+	opened := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
+	if _, err := optionService.Create("PETR4", "Put", opened, 38, opened.AddDate(0, 1, 0), 1, 1); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := positionService.Create("PETR4", opened, 100, 39); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := dividendService.Create("PETR4", opened, 0.25); err != nil {
+		t.Fatal(err)
+	}
+
+	service := NewSymbolService(db.DB)
+	symbol, err := service.QualifyLegacySymbol("PETR4", "BVMF")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if symbol.Symbol != "BVMF:PETR4" {
+		t.Fatalf("symbol = %q", symbol.Symbol)
+	}
+	if _, err := service.GetBySymbol("PETR4"); err == nil {
+		t.Fatal("legacy symbol still exists")
+	}
+	if options, _ := optionService.GetBySymbol("BVMF:PETR4"); len(options) != 1 {
+		t.Fatalf("options not moved: %d", len(options))
+	}
+	if positions, _ := positionService.GetBySymbol("BVMF:PETR4"); len(positions) != 1 {
+		t.Fatalf("positions not moved: %d", len(positions))
+	}
+	if dividends, _ := dividendService.GetBySymbol("BVMF:PETR4"); len(dividends) != 1 {
+		t.Fatalf("dividends not moved: %d", len(dividends))
+	}
+}
+
+func TestSymbolServiceCreateRejectsLegacySymbol(t *testing.T) {
+	db, err := database.NewDB(filepath.Join(t.TempDir(), "symbols.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := NewSymbolService(db.DB).Create("AAPL"); err == nil {
+		t.Fatal("expected bare ticker to be rejected")
+	}
+}

--- a/internal/polygon/client.go
+++ b/internal/polygon/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 )
 
@@ -18,62 +19,68 @@ type Client struct {
 
 // NewClient creates a new Polygon.io API client
 func NewClient(apiKey string) *Client {
-	return &Client{
-		apiKey:  apiKey,
-		baseURL: "https://api.polygon.io",
-		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
-		},
+	return NewClientWithBaseURL(apiKey, "https://api.polygon.io", nil)
+}
+
+// NewClientWithBaseURL creates a client with an explicit endpoint and HTTP
+// client. It is useful for self-hosted proxies and deterministic tests.
+func NewClientWithBaseURL(apiKey, baseURL string, httpClient *http.Client) *Client {
+	if baseURL == "" {
+		baseURL = "https://api.polygon.io"
 	}
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 30 * time.Second}
+	}
+	return &Client{apiKey: apiKey, baseURL: strings.TrimRight(baseURL, "/"), httpClient: httpClient}
 }
 
 // StockQuote represents a stock quote response from Polygon.io
 type StockQuote struct {
-	Status string `json:"status"`
+	Status  string `json:"status"`
 	Results struct {
-		Symbol           string  `json:"T"`
-		Price            float64 `json:"c"`
-		High             float64 `json:"h"`
-		Low              float64 `json:"l"`
-		Open             float64 `json:"o"`
-		Volume           float64   `json:"v"`
-		PreviousClose    float64 `json:"pc"`
-		Change           float64 `json:"change,omitempty"`
-		ChangePercent    float64 `json:"changep,omitempty"`
-		MarketStatus     string  `json:"market_status,omitempty"`
-		Timestamp        int64   `json:"t"`
+		Symbol        string  `json:"T"`
+		Price         float64 `json:"c"`
+		High          float64 `json:"h"`
+		Low           float64 `json:"l"`
+		Open          float64 `json:"o"`
+		Volume        float64 `json:"v"`
+		PreviousClose float64 `json:"pc"`
+		Change        float64 `json:"change,omitempty"`
+		ChangePercent float64 `json:"changep,omitempty"`
+		MarketStatus  string  `json:"market_status,omitempty"`
+		Timestamp     int64   `json:"t"`
 	} `json:"results"`
 	RequestID string `json:"request_id"`
 }
 
 // TickerDetails represents detailed ticker information
 type TickerDetails struct {
-	Status string `json:"status"`
+	Status  string `json:"status"`
 	Results struct {
-		Symbol              string  `json:"ticker"`
-		Name                string  `json:"name"`
-		Market              string  `json:"market"`
-		Locale              string  `json:"locale"`
-		PrimaryExchange     string  `json:"primary_exchange"`
-		Type                string  `json:"type"`
-		Active              bool    `json:"active"`
-		CurrencyName        string  `json:"currency_name"`
-		CIK                 string  `json:"cik"`
-		CompositeFigi       string  `json:"composite_figi"`
-		ShareClassFigi      string  `json:"share_class_figi"`
-		MarketCap           float64 `json:"market_cap"`
-		PhoneNumber         string  `json:"phone_number"`
-		Address             Address `json:"address"`
-		Description         string  `json:"description"`
-		SicCode             string  `json:"sic_code"`
-		SicDescription      string  `json:"sic_description"`
-		TickerRoot          string  `json:"ticker_root"`
-		HomepageURL         string  `json:"homepage_url"`
-		TotalEmployees      int     `json:"total_employees"`
-		ListDate            string  `json:"list_date"`
-		Branding            Branding `json:"branding"`
-		ShareClassSharesOutstanding int64 `json:"share_class_shares_outstanding"`
-		WeightedSharesOutstanding   int64 `json:"weighted_shares_outstanding"`
+		Symbol                      string   `json:"ticker"`
+		Name                        string   `json:"name"`
+		Market                      string   `json:"market"`
+		Locale                      string   `json:"locale"`
+		PrimaryExchange             string   `json:"primary_exchange"`
+		Type                        string   `json:"type"`
+		Active                      bool     `json:"active"`
+		CurrencyName                string   `json:"currency_name"`
+		CIK                         string   `json:"cik"`
+		CompositeFigi               string   `json:"composite_figi"`
+		ShareClassFigi              string   `json:"share_class_figi"`
+		MarketCap                   float64  `json:"market_cap"`
+		PhoneNumber                 string   `json:"phone_number"`
+		Address                     Address  `json:"address"`
+		Description                 string   `json:"description"`
+		SicCode                     string   `json:"sic_code"`
+		SicDescription              string   `json:"sic_description"`
+		TickerRoot                  string   `json:"ticker_root"`
+		HomepageURL                 string   `json:"homepage_url"`
+		TotalEmployees              int      `json:"total_employees"`
+		ListDate                    string   `json:"list_date"`
+		Branding                    Branding `json:"branding"`
+		ShareClassSharesOutstanding int64    `json:"share_class_shares_outstanding"`
+		WeightedSharesOutstanding   int64    `json:"weighted_shares_outstanding"`
 	} `json:"results"`
 	RequestID string `json:"request_id"`
 }
@@ -86,22 +93,22 @@ type Address struct {
 }
 
 type Branding struct {
-	LogoURL    string `json:"logo_url"`
-	IconURL    string `json:"icon_url"`
+	LogoURL string `json:"logo_url"`
+	IconURL string `json:"icon_url"`
 }
 
 type OptionSnapshot struct {
 	Status  string `json:"status"`
 	Results struct {
-		BreakEvenPrice   float64 `json:"break_even_price"`
-		Day              DayData `json:"day"`
-		Details          OptionDetails `json:"details"`
-		Greeks           Greeks `json:"greeks"`
-		ImpliedVolatility float64 `json:"implied_volatility"`
-		LastQuote        Quote `json:"last_quote"`
-		LastTrade        Trade `json:"last_trade"`
-		OpenInterest     float64 `json:"open_interest"`
-		UnderlyingAsset  UnderlyingAsset `json:"underlying_asset"`
+		BreakEvenPrice    float64         `json:"break_even_price"`
+		Day               DayData         `json:"day"`
+		Details           OptionDetails   `json:"details"`
+		Greeks            Greeks          `json:"greeks"`
+		ImpliedVolatility float64         `json:"implied_volatility"`
+		LastQuote         Quote           `json:"last_quote"`
+		LastTrade         Trade           `json:"last_trade"`
+		OpenInterest      float64         `json:"open_interest"`
+		UnderlyingAsset   UnderlyingAsset `json:"underlying_asset"`
 	} `json:"results"`
 	RequestID string `json:"request_id"`
 }
@@ -119,12 +126,12 @@ type DayData struct {
 }
 
 type OptionDetails struct {
-	ContractType   string  `json:"contract_type"`
-	ExerciseStyle  string  `json:"exercise_style"`
-	ExpirationDate string  `json:"expiration_date"`
+	ContractType      string  `json:"contract_type"`
+	ExerciseStyle     string  `json:"exercise_style"`
+	ExpirationDate    string  `json:"expiration_date"`
 	SharesPerContract float64 `json:"shares_per_contract"`
-	StrikePrice    float64 `json:"strike_price"`
-	Ticker         string  `json:"ticker"`
+	StrikePrice       float64 `json:"strike_price"`
+	Ticker            string  `json:"ticker"`
 }
 
 type Greeks struct {
@@ -135,21 +142,21 @@ type Greeks struct {
 }
 
 type Quote struct {
-	Ask            float64 `json:"ask"`
-	AskSize        float64 `json:"ask_size"`
-	Bid            float64 `json:"bid"`
-	BidSize        float64 `json:"bid_size"`
-	LastUpdated    int64   `json:"last_updated"`
-	Midpoint       float64 `json:"midpoint"`
-	Timeframe      string  `json:"timeframe"`
+	Ask         float64 `json:"ask"`
+	AskSize     float64 `json:"ask_size"`
+	Bid         float64 `json:"bid"`
+	BidSize     float64 `json:"bid_size"`
+	LastUpdated int64   `json:"last_updated"`
+	Midpoint    float64 `json:"midpoint"`
+	Timeframe   string  `json:"timeframe"`
 }
 
 type Trade struct {
-	Conditions      []int   `json:"conditions"`
-	Exchange        int     `json:"exchange"`
-	Price           float64 `json:"price"`
-	SipTimestamp    int64   `json:"sip_timestamp"`
-	Size            float64 `json:"size"`
+	Conditions   []int   `json:"conditions"`
+	Exchange     int     `json:"exchange"`
+	Price        float64 `json:"price"`
+	SipTimestamp int64   `json:"sip_timestamp"`
+	Size         float64 `json:"size"`
 }
 
 type UnderlyingAsset struct {
@@ -162,7 +169,7 @@ type UnderlyingAsset struct {
 
 // DividendData represents dividend information
 type DividendData struct {
-	Status string `json:"status"`
+	Status  string `json:"status"`
 	Results []struct {
 		CashAmount      float64 `json:"cash_amount"`
 		DeclarationDate string  `json:"declaration_date"`
@@ -248,17 +255,17 @@ func (c *Client) GetPreviousClose(ctx context.Context, symbol string) (*StockQuo
 	}
 
 	var result struct {
-		Status string `json:"status"`
+		Status  string `json:"status"`
 		Results []struct {
-			Symbol        string  `json:"T"`
-			Volume        float64   `json:"v"`
+			Symbol         string  `json:"T"`
+			Volume         float64 `json:"v"`
 			VolumeWeighted float64 `json:"vw"`
-			Open          float64 `json:"o"`
-			Close         float64 `json:"c"`
-			High          float64 `json:"h"`
-			Low           float64 `json:"l"`
-			Timestamp     int64   `json:"t"`
-			Transactions  int     `json:"n"`
+			Open           float64 `json:"o"`
+			Close          float64 `json:"c"`
+			High           float64 `json:"h"`
+			Low            float64 `json:"l"`
+			Timestamp      int64   `json:"t"`
+			Transactions   int     `json:"n"`
 		} `json:"results"`
 		RequestID string `json:"request_id"`
 	}
@@ -273,7 +280,7 @@ func (c *Client) GetPreviousClose(ctx context.Context, symbol string) (*StockQuo
 
 	// Convert to StockQuote format
 	quote := &StockQuote{
-		Status: result.Status,
+		Status:    result.Status,
 		RequestID: result.RequestID,
 	}
 	quote.Results.Symbol = result.Results[0].Symbol
@@ -392,7 +399,7 @@ func (c *Client) IsValidAPIKey(ctx context.Context) error {
 	if resp.StatusCode == http.StatusUnauthorized {
 		return fmt.Errorf("invalid or expired Polygon.io API key")
 	}
-	
+
 	if resp.StatusCode == http.StatusForbidden {
 		return fmt.Errorf("API key does not have permission to access Polygon.io endpoints")
 	}
@@ -409,8 +416,8 @@ func (c *Client) GetOptionSnapshot(ctx context.Context, underlyingAsset, optionC
 		return nil, fmt.Errorf("polygon API key not configured")
 	}
 
-	endpoint := fmt.Sprintf("/v3/snapshot/options/%s/%s", 
-		url.PathEscape(underlyingAsset), 
+	endpoint := fmt.Sprintf("/v3/snapshot/options/%s/%s",
+		url.PathEscape(underlyingAsset),
 		url.PathEscape(optionContract))
 	url := fmt.Sprintf("%s%s?apikey=%s", c.baseURL, endpoint, c.apiKey)
 

--- a/internal/providers/README.md
+++ b/internal/providers/README.md
@@ -26,15 +26,15 @@ type Provider interface {
 
 Google Finance is accessed through its public quote page because it does not
 provide a supported public REST API. It supports quotes and basic ticker
-details, but not dividend history. Set `DATA_PROVIDER_TYPE` to
-`google_finance` and optionally set `GOOGLE_FINANCE_EXCHANGE` (default:
-`NASDAQ`). Symbols can also include an explicit exchange, such as
-`NASDAQ:AAPL`.
+details, but not dividend history. Wheeler stores symbols as `MARKET:TICKER`,
+such as `BVMF:PETR4`, and resolves them to `PETR4:BVMF` for Google Finance. The
+legacy `GOOGLE_FINANCE_EXCHANGE` setting is not used for new symbols.
 
-The yfinance provider uses Yahoo Finance ticker symbols, such as `AAPL` or
-`PETR3.SA`, and calls Yahoo Finance's chart endpoint directly from Go. It does
-not require Python or an API key. Set `DATA_PROVIDER_TYPE` to `yfinance`.
-`YFINANCE_BASE_URL` can override the Yahoo endpoint for a proxy or tests.
+The yfinance provider receives the Yahoo Finance symbol resolved from Wheeler's
+canonical key, such as `AAPL` or `PETR4.SA`, and calls Yahoo Finance's chart
+endpoint directly from Go. It does not require Python or an API key. Set the `DATA_PROVIDER_TYPE` setting to
+`yfinance`. The `YFINANCE_BASE_URL` environment variable can override the Yahoo
+endpoint for a proxy or tests.
 
 ## Adding a New Provider
 
@@ -151,6 +151,7 @@ Rate limiting is enforced centrally in the service layer via the shared `waitFor
 
 - Polygon.io Free Tier: 5 requests/minute (enforced via the shared rate-limiting pipeline)
 - When adding a new provider, document its limits and either reuse the shared rate limiter or add provider-specific safeguards where necessary
+
 ## Error Handling
 
 Providers should wrap errors with context:

--- a/internal/providers/README.md
+++ b/internal/providers/README.md
@@ -21,6 +21,20 @@ type Provider interface {
 ### Current Providers
 
 - **Polygon.io** (`PolygonProvider`) - Default provider for stock market data
+- **Google Finance** (`GoogleFinanceProvider`) - Public quote-page provider; no API key required
+- **Yahoo Finance via yfinance** (`YFinanceProvider`) - Native Go client; no API key required
+
+Google Finance is accessed through its public quote page because it does not
+provide a supported public REST API. It supports quotes and basic ticker
+details, but not dividend history. Set `DATA_PROVIDER_TYPE` to
+`google_finance` and optionally set `GOOGLE_FINANCE_EXCHANGE` (default:
+`NASDAQ`). Symbols can also include an explicit exchange, such as
+`NASDAQ:AAPL`.
+
+The yfinance provider uses Yahoo Finance ticker symbols, such as `AAPL` or
+`PETR3.SA`, and calls Yahoo Finance's chart endpoint directly from Go. It does
+not require Python or an API key. Set `DATA_PROVIDER_TYPE` to `yfinance`.
+`YFINANCE_BASE_URL` can override the Yahoo endpoint for a proxy or tests.
 
 ## Adding a New Provider
 
@@ -35,7 +49,8 @@ package providers
 
 import (
     "context"
-    "fmt"
+    "net/http"
+    "time"
 )
 
 type AlphaVantageProvider struct {

--- a/internal/providers/README.md
+++ b/internal/providers/README.md
@@ -1,0 +1,159 @@
+# Data Provider System
+
+The Wheeler application uses a provider abstraction layer to support multiple market data sources. This design allows for easy integration of different data providers while maintaining a consistent interface.
+
+## Architecture
+
+### Provider Interface
+
+All market data providers must implement the `Provider` interface defined in `internal/providers/provider.go`:
+
+```go
+type Provider interface {
+    GetQuote(ctx context.Context, symbol string) (*Quote, error)
+    GetTickerDetails(ctx context.Context, symbol string) (*TickerDetails, error)
+    GetDividends(ctx context.Context, symbol string, limit int) ([]*Dividend, error)
+    ValidateConnection(ctx context.Context) error
+    Name() string
+}
+```
+
+### Current Providers
+
+- **Polygon.io** (`PolygonProvider`) - Default provider for stock market data
+
+## Adding a New Provider
+
+To add a new market data provider:
+
+### 1. Create Provider Implementation
+
+Create a new file in `internal/providers/` (e.g., `alphavantage.go`):
+
+```go
+package providers
+
+import (
+    "context"
+    "fmt"
+)
+
+type AlphaVantageProvider struct {
+    apiKey string
+    client *http.Client
+}
+
+func NewAlphaVantageProvider(apiKey string) *AlphaVantageProvider {
+    return &AlphaVantageProvider{
+        apiKey: apiKey,
+        client: &http.Client{Timeout: 30 * time.Second},
+    }
+}
+
+// Implement all Provider interface methods
+func (p *AlphaVantageProvider) GetQuote(ctx context.Context, symbol string) (*Quote, error) {
+    // Implementation...
+}
+
+func (p *AlphaVantageProvider) GetTickerDetails(ctx context.Context, symbol string) (*TickerDetails, error) {
+    // Implementation...
+}
+
+func (p *AlphaVantageProvider) GetDividends(ctx context.Context, symbol string, limit int) ([]*Dividend, error) {
+    // Implementation...
+}
+
+func (p *AlphaVantageProvider) ValidateConnection(ctx context.Context) error {
+    // Implementation...
+}
+
+func (p *AlphaVantageProvider) Name() string {
+    return "Alpha Vantage"
+}
+```
+
+### 2. Update Service Configuration
+
+Modify `internal/providers/service.go` to support provider selection:
+
+```go
+func (s *Service) getProvider() (Provider, error) {
+    providerType := s.settingService.GetValue("DATA_PROVIDER_TYPE")
+    
+    switch providerType {
+    case "alphavantage":
+        apiKey := s.settingService.GetValue("ALPHAVANTAGE_API_KEY")
+        return NewAlphaVantageProvider(apiKey), nil
+    case "polygon":
+        fallthrough
+    default:
+        apiKey := s.settingService.GetValue("POLYGON_API_KEY")
+        return NewPolygonProvider(apiKey), nil
+    }
+}
+```
+
+### 3. Add Settings Management
+
+Add settings for the new provider:
+- API key storage
+- Provider selection UI
+- Configuration validation
+
+### 4. Write Tests
+
+Create unit tests for the new provider:
+
+```go
+func TestAlphaVantageProvider(t *testing.T) {
+    provider := NewAlphaVantageProvider("test-key")
+    
+    ctx := context.Background()
+    quote, err := provider.GetQuote(ctx, "AAPL")
+    // Test assertions...
+}
+```
+
+### 5. Update Documentation
+
+- Update this README with provider-specific information
+- Add any rate limiting considerations
+- Document API key requirements
+
+## Provider Standards
+
+All providers should:
+1. **Handle errors gracefully** - Return descriptive errors for API failures
+2. **Respect rate limits** - Implement appropriate throttling
+3. **Cache when appropriate** - Avoid redundant API calls
+4. **Log operations** - Use structured logging for debugging
+5. **Validate inputs** - Check symbols and parameters before API calls
+6. **Context awareness** - Support cancellation via context
+
+## Rate Limiting
+
+Each provider should implement appropriate rate limiting:
+- Polygon.io Free Tier: 5 requests/minute (implemented in `Service.UpdateAllSymbolPrices`)
+- Add your provider's limits in the implementation
+
+## Error Handling
+
+Providers should wrap errors with context:
+```go
+return nil, fmt.Errorf("polygon: failed to fetch quote: %w", err)
+```
+
+This helps identify which provider caused an error in logs.
+
+## Testing
+
+Run provider tests:
+```bash
+go test ./internal/providers/
+```
+
+For integration tests with live APIs, set environment variables:
+```bash
+export POLYGON_API_KEY="your-key"
+go test ./internal/providers/ -v
+```

--- a/internal/providers/README.md
+++ b/internal/providers/README.md
@@ -132,10 +132,10 @@ All providers should:
 
 ## Rate Limiting
 
-Each provider should implement appropriate rate limiting:
-- Polygon.io Free Tier: 5 requests/minute (implemented in `Service.UpdateAllSymbolPrices`)
-- Add your provider's limits in the implementation
+Rate limiting is enforced centrally in the service layer via the shared `waitForRateLimit` / `runPriceUpdates` path, which throttles both price and dividend fetches.
 
+- Polygon.io Free Tier: 5 requests/minute (enforced via the shared rate-limiting pipeline)
+- When adding a new provider, document its limits and either reuse the shared rate limiter or add provider-specific safeguards where necessary
 ## Error Handling
 
 Providers should wrap errors with context:

--- a/internal/providers/README.md
+++ b/internal/providers/README.md
@@ -117,17 +117,11 @@ Add settings for the new provider:
 
 ### 4. Write Tests
 
-Create unit tests for the new provider:
-
-```go
-func TestAlphaVantageProvider(t *testing.T) {
-    provider := NewAlphaVantageProvider("test-key")
-    
-    ctx := context.Background()
-    quote, err := provider.GetQuote(ctx, "AAPL")
-    // Test assertions...
-}
-```
+Provider unit tests must inject an HTTP client or use an `httptest.Server`.
+They must not call a provider's production endpoint, require credentials, or
+consume an API quota. See `request_trace_test.go` for offline quote, details,
+dividend, and validation examples. Keep any intentional live checks separate
+and explicitly opt-in.
 
 ### 5. Update Documentation
 

--- a/internal/providers/google_finance.go
+++ b/internal/providers/google_finance.go
@@ -20,18 +20,28 @@ import (
 // so this provider is intentionally limited to the public quote page and may
 // require maintenance if Google's HTML changes.
 type GoogleFinanceProvider struct {
-	exchange   string
 	baseURL    string
 	httpClient *http.Client
 }
 
 var errGoogleFinanceDividendsUnsupported = errors.New("google finance does not provide dividend history through the public quote page")
 
-// NewGoogleFinanceProvider creates a provider using the supplied exchange,
-// for example "NASDAQ" or "NYSE". Symbols may also include EXCHANGE:TICKER.
-func NewGoogleFinanceProvider(exchange string) *GoogleFinanceProvider {
+var (
+	googleFinancePricePatterns = []*regexp.Regexp{
+		regexp.MustCompile(`(?is)<meta[^>]+itemprop=["']price["'][^>]+content=["']([0-9,.]+)["']`),
+		regexp.MustCompile(`(?is)<[^>]+data-last-price=["']([0-9,.]+)["']`),
+		regexp.MustCompile(`(?is)<[^>]+class=["'][^"']*YMlKec[^"']*["'][^>]*>\s*\$?\s*([0-9,.]+)`),
+	}
+	googleFinanceTitlePattern    = regexp.MustCompile(`(?is)<title[^>]*>\s*(.*?)\s*</title>`)
+	googleFinanceWhitespace      = regexp.MustCompile(`\s+`)
+	googleFinanceCurrencyPattern = regexp.MustCompile(`(?i)(?:·|&middot;)\s*([A-Z]{3})`)
+)
+
+// NewGoogleFinanceProvider creates a provider. The parameter is retained for
+// source compatibility with legacy callers; market selection now comes from
+// each canonical MARKET:TICKER symbol.
+func NewGoogleFinanceProvider(_ string) *GoogleFinanceProvider {
 	return &GoogleFinanceProvider{
-		exchange:   strings.ToUpper(strings.TrimSpace(exchange)),
 		baseURL:    "https://www.google.com",
 		httpClient: &http.Client{Timeout: 30 * time.Second},
 	}
@@ -79,7 +89,7 @@ func (p *GoogleFinanceProvider) GetTickerDetails(ctx context.Context, symbol str
 	return &TickerDetails{
 		Symbol:   ticker,
 		Name:     name,
-		Market:   p.exchange,
+		Market:   googleFinanceMarket(symbol),
 		Type:     "CS",
 		Active:   true,
 		Currency: extractGoogleFinanceCurrency(page),
@@ -119,14 +129,14 @@ func (p *GoogleFinanceProvider) ValidateConnection(ctx context.Context) error {
 func (p *GoogleFinanceProvider) Name() string { return "Google Finance" }
 
 func (p *GoogleFinanceProvider) fetchPage(ctx context.Context, symbol string) (string, error) {
-	ticker := normalizeGoogleFinanceSymbol(symbol)
-	exchange := p.exchange
-	if parts := strings.SplitN(strings.TrimSpace(symbol), ":", 2); len(parts) == 2 {
-		exchange = strings.ToUpper(strings.TrimSpace(parts[0]))
-		ticker = strings.ToUpper(strings.TrimSpace(parts[1]))
+	parts := strings.SplitN(strings.TrimSpace(symbol), ":", 2)
+	if len(parts) != 2 {
+		return "", fmt.Errorf("symbol must use TICKER:MARKET (for example AAPL:NASDAQ)")
 	}
+	ticker := strings.ToUpper(strings.TrimSpace(parts[0]))
+	exchange := strings.ToUpper(strings.TrimSpace(parts[1]))
 	if ticker == "" || exchange == "" {
-		return "", fmt.Errorf("symbol must include a ticker and exchange (for example AAPL or NASDAQ:AAPL)")
+		return "", fmt.Errorf("symbol must use TICKER:MARKET (for example AAPL:NASDAQ)")
 	}
 
 	path := "/finance/quote/" + url.PathEscape(ticker+":"+exchange)
@@ -142,6 +152,9 @@ func (p *GoogleFinanceProvider) fetchPage(ctx context.Context, symbol string) (s
 		return "", fmt.Errorf("execute request: %w", err)
 	}
 	defer response.Body.Close()
+	if response.StatusCode == http.StatusNotFound {
+		return "", fmt.Errorf("unknown symbol %q", symbol)
+	}
 	if response.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("quote page returned HTTP %d", response.StatusCode)
 	}
@@ -154,13 +167,8 @@ func (p *GoogleFinanceProvider) fetchPage(ctx context.Context, symbol string) (s
 }
 
 func extractGoogleFinancePrice(page string) (float64, error) {
-	patterns := []string{
-		`(?is)<meta[^>]+itemprop=["']price["'][^>]+content=["']([0-9,.]+)["']`,
-		`(?is)<[^>]+data-last-price=["']([0-9,.]+)["']`,
-		`(?is)<[^>]+class=["'][^"']*YMlKec[^"']*["'][^>]*>\s*\$?\s*([0-9,.]+)`,
-	}
-	for _, pattern := range patterns {
-		match := regexp.MustCompile(pattern).FindStringSubmatch(page)
+	for _, pattern := range googleFinancePricePatterns {
+		match := pattern.FindStringSubmatch(page)
 		if len(match) < 2 {
 			continue
 		}
@@ -173,11 +181,11 @@ func extractGoogleFinancePrice(page string) (float64, error) {
 }
 
 func extractGoogleFinanceTitle(page string) string {
-	match := regexp.MustCompile(`(?is)<title[^>]*>\s*(.*?)\s*</title>`).FindStringSubmatch(page)
+	match := googleFinanceTitlePattern.FindStringSubmatch(page)
 	if len(match) < 2 {
 		return ""
 	}
-	title := strings.TrimSpace(regexp.MustCompile(`\s+`).ReplaceAllString(match[1], " "))
+	title := strings.TrimSpace(googleFinanceWhitespace.ReplaceAllString(match[1], " "))
 	if index := strings.Index(title, " ("); index > 0 {
 		return title[:index]
 	}
@@ -185,7 +193,7 @@ func extractGoogleFinanceTitle(page string) string {
 }
 
 func extractGoogleFinanceCurrency(page string) string {
-	match := regexp.MustCompile(`(?i)(?:·|&middot;)\s*([A-Z]{3})`).FindStringSubmatch(page)
+	match := googleFinanceCurrencyPattern.FindStringSubmatch(page)
 	if len(match) >= 2 {
 		return match[1]
 	}
@@ -195,7 +203,15 @@ func extractGoogleFinanceCurrency(page string) string {
 func normalizeGoogleFinanceSymbol(symbol string) string {
 	parts := strings.SplitN(strings.TrimSpace(symbol), ":", 2)
 	if len(parts) == 2 {
-		return strings.ToUpper(strings.TrimSpace(parts[1]))
+		return strings.ToUpper(strings.TrimSpace(parts[0]))
 	}
 	return strings.ToUpper(strings.TrimSpace(symbol))
+}
+
+func googleFinanceMarket(symbol string) string {
+	parts := strings.SplitN(strings.TrimSpace(symbol), ":", 2)
+	if len(parts) == 2 {
+		return strings.ToUpper(strings.TrimSpace(parts[1]))
+	}
+	return ""
 }

--- a/internal/providers/google_finance.go
+++ b/internal/providers/google_finance.go
@@ -1,0 +1,201 @@
+package providers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"html"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// GoogleFinanceProvider reads the public Google Finance quote page.
+//
+// Google Finance does not currently expose a supported public market-data API,
+// so this provider is intentionally limited to the public quote page and may
+// require maintenance if Google's HTML changes.
+type GoogleFinanceProvider struct {
+	exchange   string
+	baseURL    string
+	httpClient *http.Client
+}
+
+var errGoogleFinanceDividendsUnsupported = errors.New("google finance does not provide dividend history through the public quote page")
+
+// NewGoogleFinanceProvider creates a provider using the supplied exchange,
+// for example "NASDAQ" or "NYSE". Symbols may also include EXCHANGE:TICKER.
+func NewGoogleFinanceProvider(exchange string) *GoogleFinanceProvider {
+	return &GoogleFinanceProvider{
+		exchange:   strings.ToUpper(strings.TrimSpace(exchange)),
+		baseURL:    "https://www.google.com",
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+func newGoogleFinanceProviderForTest(client *http.Client, baseURL, exchange string) *GoogleFinanceProvider {
+	p := NewGoogleFinanceProvider(exchange)
+	p.httpClient = client
+	p.baseURL = strings.TrimRight(baseURL, "/")
+	return p
+}
+
+func (p *GoogleFinanceProvider) GetQuote(ctx context.Context, symbol string) (*Quote, error) {
+	page, err := p.fetchPage(ctx, symbol)
+	if err != nil {
+		return nil, fmt.Errorf("google finance: %w", err)
+	}
+
+	price, err := extractGoogleFinancePrice(page)
+	if err != nil {
+		return nil, fmt.Errorf("google finance: %w", err)
+	}
+
+	return &Quote{
+		Symbol: normalizeGoogleFinanceSymbol(symbol),
+		Price:  price,
+		// The public page parser currently extracts only the current price.
+		// Leave fields we did not observe at zero instead of duplicating data.
+		Timestamp: time.Now(),
+	}, nil
+}
+
+func (p *GoogleFinanceProvider) GetTickerDetails(ctx context.Context, symbol string) (*TickerDetails, error) {
+	page, err := p.fetchPage(ctx, symbol)
+	if err != nil {
+		return nil, fmt.Errorf("google finance: %w", err)
+	}
+
+	ticker := normalizeGoogleFinanceSymbol(symbol)
+	name := extractGoogleFinanceTitle(page)
+	if name == "" {
+		name = ticker
+	}
+
+	return &TickerDetails{
+		Symbol:   ticker,
+		Name:     name,
+		Market:   p.exchange,
+		Type:     "CS",
+		Active:   true,
+		Currency: extractGoogleFinanceCurrency(page),
+	}, nil
+}
+
+// GetDividends cannot provide a history from the public quote page. Returning
+// an explicit error prevents the application from treating missing data as a
+// zero-dividend history.
+func (p *GoogleFinanceProvider) GetDividends(_ context.Context, _ string, _ int) ([]*Dividend, error) {
+	return nil, errGoogleFinanceDividendsUnsupported
+}
+
+func (p *GoogleFinanceProvider) ValidateConnection(ctx context.Context) error {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(p.baseURL, "/")+"/finance/?hl=en", nil)
+	if err != nil {
+		return fmt.Errorf("google finance: create connection request: %w", err)
+	}
+	request.Header.Set("Accept", "text/html,application/xhtml+xml")
+	request.Header.Set("User-Agent", "Wheeler/1.0 (+https://github.com/phbrgnomo/wheeler)")
+
+	response, err := p.httpClient.Do(request)
+	if err != nil {
+		return fmt.Errorf("google finance: execute connection request: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("google finance: connection page returned HTTP %d", response.StatusCode)
+	}
+	_, err = io.Copy(io.Discard, io.LimitReader(response.Body, 1024))
+	if err != nil {
+		return fmt.Errorf("google finance: read connection response: %w", err)
+	}
+	return nil
+}
+
+func (p *GoogleFinanceProvider) Name() string { return "Google Finance" }
+
+func (p *GoogleFinanceProvider) fetchPage(ctx context.Context, symbol string) (string, error) {
+	ticker := normalizeGoogleFinanceSymbol(symbol)
+	exchange := p.exchange
+	if parts := strings.SplitN(strings.TrimSpace(symbol), ":", 2); len(parts) == 2 {
+		exchange = strings.ToUpper(strings.TrimSpace(parts[0]))
+		ticker = strings.ToUpper(strings.TrimSpace(parts[1]))
+	}
+	if ticker == "" || exchange == "" {
+		return "", fmt.Errorf("symbol must include a ticker and exchange (for example AAPL or NASDAQ:AAPL)")
+	}
+
+	path := "/finance/quote/" + url.PathEscape(ticker+":"+exchange)
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(p.baseURL, "/")+path+"?hl=en", nil)
+	if err != nil {
+		return "", fmt.Errorf("create request: %w", err)
+	}
+	request.Header.Set("Accept", "text/html,application/xhtml+xml")
+	request.Header.Set("User-Agent", "Wheeler/1.0 (+https://github.com/phbrgnomo/wheeler)")
+
+	response, err := p.httpClient.Do(request)
+	if err != nil {
+		return "", fmt.Errorf("execute request: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("quote page returned HTTP %d", response.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(response.Body, 8<<20))
+	if err != nil {
+		return "", fmt.Errorf("read response: %w", err)
+	}
+	return html.UnescapeString(string(body)), nil
+}
+
+func extractGoogleFinancePrice(page string) (float64, error) {
+	patterns := []string{
+		`(?is)<meta[^>]+itemprop=["']price["'][^>]+content=["']([0-9,.]+)["']`,
+		`(?is)<[^>]+data-last-price=["']([0-9,.]+)["']`,
+		`(?is)<[^>]+class=["'][^"']*YMlKec[^"']*["'][^>]*>\s*\$?\s*([0-9,.]+)`,
+	}
+	for _, pattern := range patterns {
+		match := regexp.MustCompile(pattern).FindStringSubmatch(page)
+		if len(match) < 2 {
+			continue
+		}
+		value, err := strconv.ParseFloat(strings.ReplaceAll(match[1], ",", ""), 64)
+		if err == nil && value > 0 {
+			return value, nil
+		}
+	}
+	return 0, errors.New("current price was not found in the quote page")
+}
+
+func extractGoogleFinanceTitle(page string) string {
+	match := regexp.MustCompile(`(?is)<title[^>]*>\s*(.*?)\s*</title>`).FindStringSubmatch(page)
+	if len(match) < 2 {
+		return ""
+	}
+	title := strings.TrimSpace(regexp.MustCompile(`\s+`).ReplaceAllString(match[1], " "))
+	if index := strings.Index(title, " ("); index > 0 {
+		return title[:index]
+	}
+	return strings.TrimSuffix(title, " Stock Price & News - Google Finance")
+}
+
+func extractGoogleFinanceCurrency(page string) string {
+	match := regexp.MustCompile(`(?i)(?:·|&middot;)\s*([A-Z]{3})`).FindStringSubmatch(page)
+	if len(match) >= 2 {
+		return match[1]
+	}
+	return ""
+}
+
+func normalizeGoogleFinanceSymbol(symbol string) string {
+	parts := strings.SplitN(strings.TrimSpace(symbol), ":", 2)
+	if len(parts) == 2 {
+		return strings.ToUpper(strings.TrimSpace(parts[1]))
+	}
+	return strings.ToUpper(strings.TrimSpace(symbol))
+}

--- a/internal/providers/google_finance_test.go
+++ b/internal/providers/google_finance_test.go
@@ -1,0 +1,86 @@
+package providers
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+const googleFinanceFixture = `<!doctype html>
+<html><head><title>Apple Inc (AAPL) Stock Price &amp; News - Google Finance</title></head>
+<body><meta itemprop="price" content="189.42"><span>· USD</span></body></html>`
+
+type googleFinanceRoundTripper struct {
+	body string
+}
+
+type googleFinanceValidationRoundTripper struct{}
+
+func (googleFinanceValidationRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	if request.URL.Path != "/finance/" {
+		return nil, fmt.Errorf("validation must not use an exchange-specific quote path: %s", request.URL.Path)
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("Google Finance")),
+		Header:     make(http.Header),
+		Request:    request,
+	}, nil
+}
+
+func (t googleFinanceRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	if request.URL.Path != "/finance/quote/AAPL:NASDAQ" {
+		return nil, fmt.Errorf("unexpected path: %s", request.URL.Path)
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(t.body)),
+		Header:     make(http.Header),
+		Request:    request,
+	}, nil
+}
+
+func TestGoogleFinanceProviderQuoteAndDetails(t *testing.T) {
+	provider := newGoogleFinanceProviderForTest(&http.Client{Transport: googleFinanceRoundTripper{body: googleFinanceFixture}}, "http://google.test", "NASDAQ")
+	quote, err := provider.GetQuote(context.Background(), "AAPL")
+	if err != nil {
+		t.Fatalf("GetQuote failed: %v", err)
+	}
+	if quote.Symbol != "AAPL" || quote.Price != 189.42 {
+		t.Fatalf("unexpected quote: %+v", quote)
+	}
+
+	details, err := provider.GetTickerDetails(context.Background(), "NASDAQ:AAPL")
+	if err != nil {
+		t.Fatalf("GetTickerDetails failed: %v", err)
+	}
+	if details.Name != "Apple Inc" || details.Currency != "USD" || details.Market != "NASDAQ" {
+		t.Fatalf("unexpected details: %+v", details)
+	}
+}
+
+func TestGoogleFinanceProviderMissingPrice(t *testing.T) {
+	provider := newGoogleFinanceProviderForTest(&http.Client{Transport: googleFinanceRoundTripper{body: "<html><title>Not found</title></html>"}}, "http://google.test", "NASDAQ")
+	_, err := provider.GetQuote(context.Background(), "AAPL")
+	if err == nil || !strings.Contains(err.Error(), "current price was not found") {
+		t.Fatalf("expected missing-price error, got %v", err)
+	}
+}
+
+func TestGoogleFinanceProviderDividendsAreExplicitlyUnsupported(t *testing.T) {
+	provider := NewGoogleFinanceProvider("NASDAQ")
+	_, err := provider.GetDividends(context.Background(), "AAPL", 10)
+	if err != errGoogleFinanceDividendsUnsupported {
+		t.Fatalf("expected unsupported dividend error, got %v", err)
+	}
+}
+
+func TestGoogleFinanceProviderValidationDoesNotDependOnConfiguredExchange(t *testing.T) {
+	provider := newGoogleFinanceProviderForTest(&http.Client{Transport: googleFinanceValidationRoundTripper{}}, "http://google.test", "NYSE")
+	if err := provider.ValidateConnection(context.Background()); err != nil {
+		t.Fatalf("ValidateConnection failed for NYSE provider: %v", err)
+	}
+}

--- a/internal/providers/google_finance_test.go
+++ b/internal/providers/google_finance_test.go
@@ -2,6 +2,7 @@ package providers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -14,7 +15,8 @@ const googleFinanceFixture = `<!doctype html>
 <body><meta itemprop="price" content="189.42"><span>· USD</span></body></html>`
 
 type googleFinanceRoundTripper struct {
-	body string
+	body       string
+	statusCode int
 }
 
 type googleFinanceValidationRoundTripper struct{}
@@ -32,11 +34,15 @@ func (googleFinanceValidationRoundTripper) RoundTrip(request *http.Request) (*ht
 }
 
 func (t googleFinanceRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
-	if request.URL.Path != "/finance/quote/AAPL:NASDAQ" {
+	if request.URL.Path != "/finance/quote/AAPL:NASDAQ" && request.URL.Path != "/finance/quote/MISSING:NASDAQ" {
 		return nil, fmt.Errorf("unexpected path: %s", request.URL.Path)
 	}
+	statusCode := t.statusCode
+	if statusCode == 0 {
+		statusCode = http.StatusOK
+	}
 	return &http.Response{
-		StatusCode: http.StatusOK,
+		StatusCode: statusCode,
 		Body:       io.NopCloser(strings.NewReader(t.body)),
 		Header:     make(http.Header),
 		Request:    request,
@@ -45,7 +51,7 @@ func (t googleFinanceRoundTripper) RoundTrip(request *http.Request) (*http.Respo
 
 func TestGoogleFinanceProviderQuoteAndDetails(t *testing.T) {
 	provider := newGoogleFinanceProviderForTest(&http.Client{Transport: googleFinanceRoundTripper{body: googleFinanceFixture}}, "http://google.test", "NASDAQ")
-	quote, err := provider.GetQuote(context.Background(), "AAPL")
+	quote, err := provider.GetQuote(context.Background(), "AAPL:NASDAQ")
 	if err != nil {
 		t.Fatalf("GetQuote failed: %v", err)
 	}
@@ -53,7 +59,7 @@ func TestGoogleFinanceProviderQuoteAndDetails(t *testing.T) {
 		t.Fatalf("unexpected quote: %+v", quote)
 	}
 
-	details, err := provider.GetTickerDetails(context.Background(), "NASDAQ:AAPL")
+	details, err := provider.GetTickerDetails(context.Background(), "AAPL:NASDAQ")
 	if err != nil {
 		t.Fatalf("GetTickerDetails failed: %v", err)
 	}
@@ -64,16 +70,24 @@ func TestGoogleFinanceProviderQuoteAndDetails(t *testing.T) {
 
 func TestGoogleFinanceProviderMissingPrice(t *testing.T) {
 	provider := newGoogleFinanceProviderForTest(&http.Client{Transport: googleFinanceRoundTripper{body: "<html><title>Not found</title></html>"}}, "http://google.test", "NASDAQ")
-	_, err := provider.GetQuote(context.Background(), "AAPL")
+	_, err := provider.GetQuote(context.Background(), "AAPL:NASDAQ")
 	if err == nil || !strings.Contains(err.Error(), "current price was not found") {
 		t.Fatalf("expected missing-price error, got %v", err)
+	}
+}
+
+func TestGoogleFinanceProviderUnknownSymbol(t *testing.T) {
+	provider := newGoogleFinanceProviderForTest(&http.Client{Transport: googleFinanceRoundTripper{statusCode: http.StatusNotFound}}, "http://google.test", "")
+	_, err := provider.GetQuote(context.Background(), "MISSING:NASDAQ")
+	if err == nil || !strings.Contains(err.Error(), `unknown symbol "MISSING:NASDAQ"`) {
+		t.Fatalf("expected unknown-symbol error, got %v", err)
 	}
 }
 
 func TestGoogleFinanceProviderDividendsAreExplicitlyUnsupported(t *testing.T) {
 	provider := NewGoogleFinanceProvider("NASDAQ")
 	_, err := provider.GetDividends(context.Background(), "AAPL", 10)
-	if err != errGoogleFinanceDividendsUnsupported {
+	if !errors.Is(err, errGoogleFinanceDividendsUnsupported) {
 		t.Fatalf("expected unsupported dividend error, got %v", err)
 	}
 }

--- a/internal/providers/polygon.go
+++ b/internal/providers/polygon.go
@@ -19,6 +19,10 @@ func NewPolygonProvider(apiKey string) *PolygonProvider {
 	}
 }
 
+func newPolygonProviderForTest(client *polygon.Client) *PolygonProvider {
+	return &PolygonProvider{client: client}
+}
+
 // GetQuote retrieves the current or most recent quote for a symbol
 func (p *PolygonProvider) GetQuote(ctx context.Context, symbol string) (*Quote, error) {
 	polygonQuote, err := p.client.GetPreviousClose(ctx, symbol)
@@ -27,14 +31,13 @@ func (p *PolygonProvider) GetQuote(ctx context.Context, symbol string) (*Quote, 
 	}
 
 	return &Quote{
-		Symbol:        polygonQuote.Results.Symbol,
-		Price:         polygonQuote.Results.Price,
-		Open:          polygonQuote.Results.Open,
-		High:          polygonQuote.Results.High,
-		Low:           polygonQuote.Results.Low,
-		Volume:        polygonQuote.Results.Volume,
-		PreviousClose: polygonQuote.Results.PreviousClose,
-		Timestamp:     time.Unix(0, polygonQuote.Results.Timestamp*int64(time.Millisecond)),
+		Symbol:    polygonQuote.Results.Symbol,
+		Price:     polygonQuote.Results.Price,
+		Open:      polygonQuote.Results.Open,
+		High:      polygonQuote.Results.High,
+		Low:       polygonQuote.Results.Low,
+		Volume:    polygonQuote.Results.Volume,
+		Timestamp: time.Unix(0, polygonQuote.Results.Timestamp*int64(time.Millisecond)),
 	}, nil
 }
 

--- a/internal/providers/polygon.go
+++ b/internal/providers/polygon.go
@@ -31,13 +31,17 @@ func (p *PolygonProvider) GetQuote(ctx context.Context, symbol string) (*Quote, 
 	}
 
 	return &Quote{
-		Symbol:    polygonQuote.Results.Symbol,
-		Price:     polygonQuote.Results.Price,
-		Open:      polygonQuote.Results.Open,
-		High:      polygonQuote.Results.High,
-		Low:       polygonQuote.Results.Low,
-		Volume:    polygonQuote.Results.Volume,
-		Timestamp: time.Unix(0, polygonQuote.Results.Timestamp*int64(time.Millisecond)),
+		Symbol: polygonQuote.Results.Symbol,
+		// Polygon's /prev aggregate exposes the prior session's close as its
+		// only close value. It is therefore both the returned price and the
+		// best available previous-close value without another market-data call.
+		Price:         polygonQuote.Results.Price,
+		PreviousClose: polygonQuote.Results.Price,
+		Open:          polygonQuote.Results.Open,
+		High:          polygonQuote.Results.High,
+		Low:           polygonQuote.Results.Low,
+		Volume:        polygonQuote.Results.Volume,
+		Timestamp:     time.Unix(0, polygonQuote.Results.Timestamp*int64(time.Millisecond)),
 	}, nil
 }
 

--- a/internal/providers/polygon.go
+++ b/internal/providers/polygon.go
@@ -1,0 +1,94 @@
+package providers
+
+import (
+	"context"
+	"fmt"
+	"stonks/internal/polygon"
+	"time"
+)
+
+// PolygonProvider implements the Provider interface using Polygon.io
+type PolygonProvider struct {
+	client *polygon.Client
+}
+
+// NewPolygonProvider creates a new Polygon.io provider
+func NewPolygonProvider(apiKey string) *PolygonProvider {
+	return &PolygonProvider{
+		client: polygon.NewClient(apiKey),
+	}
+}
+
+// GetQuote retrieves the current or most recent quote for a symbol
+func (p *PolygonProvider) GetQuote(ctx context.Context, symbol string) (*Quote, error) {
+	polygonQuote, err := p.client.GetPreviousClose(ctx, symbol)
+	if err != nil {
+		return nil, fmt.Errorf("polygon: %w", err)
+	}
+
+	return &Quote{
+		Symbol:        polygonQuote.Results.Symbol,
+		Price:         polygonQuote.Results.Price,
+		Open:          polygonQuote.Results.Open,
+		High:          polygonQuote.Results.High,
+		Low:           polygonQuote.Results.Low,
+		Volume:        polygonQuote.Results.Volume,
+		PreviousClose: polygonQuote.Results.PreviousClose,
+		Timestamp:     time.Unix(0, polygonQuote.Results.Timestamp*int64(time.Millisecond)),
+	}, nil
+}
+
+// GetTickerDetails retrieves detailed information about a ticker
+func (p *PolygonProvider) GetTickerDetails(ctx context.Context, symbol string) (*TickerDetails, error) {
+	details, err := p.client.GetTickerDetails(ctx, symbol)
+	if err != nil {
+		return nil, fmt.Errorf("polygon: %w", err)
+	}
+
+	return &TickerDetails{
+		Symbol:      details.Results.Symbol,
+		Name:        details.Results.Name,
+		Market:      details.Results.Market,
+		Type:        details.Results.Type,
+		Active:      details.Results.Active,
+		Currency:    details.Results.CurrencyName,
+		Description: details.Results.Description,
+		Homepage:    details.Results.HomepageURL,
+		MarketCap:   details.Results.MarketCap,
+		Employees:   details.Results.TotalEmployees,
+	}, nil
+}
+
+// GetDividends retrieves dividend history for a symbol
+func (p *PolygonProvider) GetDividends(ctx context.Context, symbol string, limit int) ([]*Dividend, error) {
+	dividends, err := p.client.GetDividends(ctx, symbol, limit)
+	if err != nil {
+		return nil, fmt.Errorf("polygon: %w", err)
+	}
+
+	result := make([]*Dividend, 0, len(dividends.Results))
+	for _, div := range dividends.Results {
+		result = append(result, &Dividend{
+			Symbol:          div.Ticker,
+			CashAmount:      div.CashAmount,
+			DeclarationDate: div.DeclarationDate,
+			ExDividendDate:  div.ExDividendDate,
+			PayDate:         div.PayDate,
+			RecordDate:      div.RecordDate,
+			DividendType:    div.DividendType,
+			Frequency:       div.Frequency,
+		})
+	}
+
+	return result, nil
+}
+
+// ValidateConnection tests if the provider connection is working
+func (p *PolygonProvider) ValidateConnection(ctx context.Context) error {
+	return p.client.IsValidAPIKey(ctx)
+}
+
+// Name returns the provider's name
+func (p *PolygonProvider) Name() string {
+	return "Polygon.io"
+}

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -1,0 +1,62 @@
+package providers
+
+import (
+	"context"
+	"time"
+)
+
+// Provider defines the interface for market data providers
+type Provider interface {
+	// GetQuote retrieves the current or most recent quote for a symbol
+	GetQuote(ctx context.Context, symbol string) (*Quote, error)
+	
+	// GetTickerDetails retrieves detailed information about a ticker
+	GetTickerDetails(ctx context.Context, symbol string) (*TickerDetails, error)
+	
+	// GetDividends retrieves dividend history for a symbol
+	GetDividends(ctx context.Context, symbol string, limit int) ([]*Dividend, error)
+	
+	// ValidateConnection tests if the provider connection is working
+	ValidateConnection(ctx context.Context) error
+	
+	// Name returns the provider's name
+	Name() string
+}
+
+// Quote represents a stock quote from any provider
+type Quote struct {
+	Symbol        string
+	Price         float64
+	Open          float64
+	High          float64
+	Low           float64
+	Volume        float64
+	PreviousClose float64
+	Timestamp     time.Time
+}
+
+// TickerDetails represents detailed ticker information from any provider
+type TickerDetails struct {
+	Symbol      string
+	Name        string
+	Market      string
+	Type        string
+	Active      bool
+	Currency    string
+	Description string
+	Homepage    string
+	MarketCap   float64
+	Employees   int
+}
+
+// Dividend represents dividend information from any provider
+type Dividend struct {
+	Symbol          string
+	CashAmount      float64
+	DeclarationDate string
+	ExDividendDate  string
+	PayDate         string
+	RecordDate      string
+	DividendType    string
+	Frequency       int
+}

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -9,16 +9,15 @@ import (
 type Provider interface {
 	// GetQuote retrieves the current or most recent quote for a symbol
 	GetQuote(ctx context.Context, symbol string) (*Quote, error)
-	
+
 	// GetTickerDetails retrieves detailed information about a ticker
 	GetTickerDetails(ctx context.Context, symbol string) (*TickerDetails, error)
-	
+
 	// GetDividends retrieves dividend history for a symbol
 	GetDividends(ctx context.Context, symbol string, limit int) ([]*Dividend, error)
-	
+
 	// ValidateConnection tests if the provider connection is working
 	ValidateConnection(ctx context.Context) error
-	
 	// Name returns the provider's name
 	Name() string
 }

--- a/internal/providers/provider_test.go
+++ b/internal/providers/provider_test.go
@@ -59,6 +59,17 @@ func TestProviderInterface(t *testing.T) {
 	}
 
 	// Test GetQuote
+	// Test with custom quote function
+	mock.quoteFunc = func(ctx context.Context, symbol string) (*Quote, error) {
+		return &Quote{Symbol: symbol, Price: 150.5}, nil
+	}
+	quote, err = mock.GetQuote(ctx, "TSLA")
+	if err != nil {
+		t.Fatalf("GetQuote with custom func failed: %v", err)
+	}
+	if quote.Price != 150.5 {
+		t.Errorf("Expected custom price 150.5, got %.2f", quote.Price)
+	}
 	quote, err := mock.GetQuote(ctx, "AAPL")
 	if err != nil {
 		t.Fatalf("GetQuote failed: %v", err)

--- a/internal/providers/provider_test.go
+++ b/internal/providers/provider_test.go
@@ -1,0 +1,95 @@
+package providers
+
+import (
+	"context"
+	"testing"
+)
+
+// MockProvider implements Provider interface for testing
+type MockProvider struct {
+	name            string
+	quoteFunc       func(ctx context.Context, symbol string) (*Quote, error)
+	detailsFunc     func(ctx context.Context, symbol string) (*TickerDetails, error)
+	dividendsFunc   func(ctx context.Context, symbol string, limit int) ([]*Dividend, error)
+	validateFunc    func(ctx context.Context) error
+}
+
+func (m *MockProvider) GetQuote(ctx context.Context, symbol string) (*Quote, error) {
+	if m.quoteFunc != nil {
+		return m.quoteFunc(ctx, symbol)
+	}
+	return &Quote{Symbol: symbol, Price: 100.0}, nil
+}
+
+func (m *MockProvider) GetTickerDetails(ctx context.Context, symbol string) (*TickerDetails, error) {
+	if m.detailsFunc != nil {
+		return m.detailsFunc(ctx, symbol)
+	}
+	return &TickerDetails{Symbol: symbol, Name: "Test Company"}, nil
+}
+
+func (m *MockProvider) GetDividends(ctx context.Context, symbol string, limit int) ([]*Dividend, error) {
+	if m.dividendsFunc != nil {
+		return m.dividendsFunc(ctx, symbol, limit)
+	}
+	return []*Dividend{{Symbol: symbol, CashAmount: 1.0}}, nil
+}
+
+func (m *MockProvider) ValidateConnection(ctx context.Context) error {
+	if m.validateFunc != nil {
+		return m.validateFunc(ctx)
+	}
+	return nil
+}
+
+func (m *MockProvider) Name() string {
+	if m.name != "" {
+		return m.name
+	}
+	return "MockProvider"
+}
+
+func TestProviderInterface(t *testing.T) {
+	ctx := context.Background()
+	mock := &MockProvider{name: "TestProvider"}
+
+	// Test Name
+	if name := mock.Name(); name != "TestProvider" {
+		t.Errorf("Expected name 'TestProvider', got '%s'", name)
+	}
+
+	// Test GetQuote
+	quote, err := mock.GetQuote(ctx, "AAPL")
+	if err != nil {
+		t.Fatalf("GetQuote failed: %v", err)
+	}
+	if quote.Symbol != "AAPL" {
+		t.Errorf("Expected symbol 'AAPL', got '%s'", quote.Symbol)
+	}
+	if quote.Price != 100.0 {
+		t.Errorf("Expected price 100.0, got %.2f", quote.Price)
+	}
+
+	// Test GetTickerDetails
+	details, err := mock.GetTickerDetails(ctx, "AAPL")
+	if err != nil {
+		t.Fatalf("GetTickerDetails failed: %v", err)
+	}
+	if details.Symbol != "AAPL" {
+		t.Errorf("Expected symbol 'AAPL', got '%s'", details.Symbol)
+	}
+
+	// Test GetDividends
+	dividends, err := mock.GetDividends(ctx, "AAPL", 10)
+	if err != nil {
+		t.Fatalf("GetDividends failed: %v", err)
+	}
+	if len(dividends) != 1 {
+		t.Errorf("Expected 1 dividend, got %d", len(dividends))
+	}
+
+	// Test ValidateConnection
+	if err := mock.ValidateConnection(ctx); err != nil {
+		t.Errorf("ValidateConnection failed: %v", err)
+	}
+}

--- a/internal/providers/provider_test.go
+++ b/internal/providers/provider_test.go
@@ -49,6 +49,8 @@ func (m *MockProvider) Name() string {
 	return "MockProvider"
 }
 
+var _ Provider = (*PolygonProvider)(nil)
+
 func TestProviderInterface(t *testing.T) {
 	ctx := context.Background()
 	mock := &MockProvider{name: "TestProvider"}

--- a/internal/providers/provider_test.go
+++ b/internal/providers/provider_test.go
@@ -7,11 +7,11 @@ import (
 
 // MockProvider implements Provider interface for testing
 type MockProvider struct {
-	name            string
-	quoteFunc       func(ctx context.Context, symbol string) (*Quote, error)
-	detailsFunc     func(ctx context.Context, symbol string) (*TickerDetails, error)
-	dividendsFunc   func(ctx context.Context, symbol string, limit int) ([]*Dividend, error)
-	validateFunc    func(ctx context.Context) error
+	name          string
+	quoteFunc     func(ctx context.Context, symbol string) (*Quote, error)
+	detailsFunc   func(ctx context.Context, symbol string) (*TickerDetails, error)
+	dividendsFunc func(ctx context.Context, symbol string, limit int) ([]*Dividend, error)
+	validateFunc  func(ctx context.Context) error
 }
 
 func (m *MockProvider) GetQuote(ctx context.Context, symbol string) (*Quote, error) {
@@ -59,6 +59,17 @@ func TestProviderInterface(t *testing.T) {
 	}
 
 	// Test GetQuote
+	quote, err := mock.GetQuote(ctx, "AAPL")
+	if err != nil {
+		t.Fatalf("GetQuote failed: %v", err)
+	}
+	if quote.Symbol != "AAPL" {
+		t.Errorf("Expected symbol 'AAPL', got '%s'", quote.Symbol)
+	}
+	if quote.Price != 100.0 {
+		t.Errorf("Expected price 100.0, got %.2f", quote.Price)
+	}
+
 	// Test with custom quote function
 	mock.quoteFunc = func(ctx context.Context, symbol string) (*Quote, error) {
 		return &Quote{Symbol: symbol, Price: 150.5}, nil
@@ -69,16 +80,6 @@ func TestProviderInterface(t *testing.T) {
 	}
 	if quote.Price != 150.5 {
 		t.Errorf("Expected custom price 150.5, got %.2f", quote.Price)
-	}
-	quote, err := mock.GetQuote(ctx, "AAPL")
-	if err != nil {
-		t.Fatalf("GetQuote failed: %v", err)
-	}
-	if quote.Symbol != "AAPL" {
-		t.Errorf("Expected symbol 'AAPL', got '%s'", quote.Symbol)
-	}
-	if quote.Price != 100.0 {
-		t.Errorf("Expected price 100.0, got %.2f", quote.Price)
 	}
 
 	// Test GetTickerDetails

--- a/internal/providers/provider_test.go
+++ b/internal/providers/provider_test.go
@@ -49,7 +49,7 @@ func (m *MockProvider) Name() string {
 	return "MockProvider"
 }
 
-var _ Provider = (*PolygonProvider)(nil)
+var _ Provider = (*MockProvider)(nil)
 
 func TestProviderInterface(t *testing.T) {
 	ctx := context.Background()

--- a/internal/providers/request_trace_test.go
+++ b/internal/providers/request_trace_test.go
@@ -170,7 +170,7 @@ func TestProviderRequestTraces(t *testing.T) {
 			t.Fatal(err)
 		}
 		assertAndLogTrace(t, "polygon", "quote", transport.calls[0], "http://polygon.test/v2/aggs/ticker/AAPL/prev?adjusted=true&apikey=REDACTED", "price:189.42")
-		if quote.Price != 189.42 {
+		if quote.Price != 189.42 || quote.PreviousClose != 189.42 {
 			t.Fatalf("unexpected quote: %+v", quote)
 		}
 

--- a/internal/providers/request_trace_test.go
+++ b/internal/providers/request_trace_test.go
@@ -1,0 +1,234 @@
+package providers
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"stonks/internal/polygon"
+)
+
+type requestTrace struct {
+	Method string
+	URL    string
+	Status int
+}
+
+type recordingTransport struct {
+	handler func(*http.Request) (*http.Response, error)
+	calls   []requestTrace
+}
+
+func (t *recordingTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	response, err := t.handler(request)
+	if response != nil {
+		t.calls = append(t.calls, requestTrace{
+			Method: request.Method,
+			URL:    sanitizeRequestURL(request.URL),
+			Status: response.StatusCode,
+		})
+	}
+	return response, err
+}
+
+func sanitizeRequestURL(value *url.URL) string {
+	copyURL := *value
+	query := copyURL.Query()
+	for _, key := range []string{"apikey", "api_key", "token"} {
+		if query.Has(key) {
+			query.Set(key, "REDACTED")
+		}
+	}
+	copyURL.RawQuery = query.Encode()
+	return copyURL.String()
+}
+
+func traceResponse(status int, body string) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: status,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}, nil
+}
+
+func assertAndLogTrace(t *testing.T, provider, operation string, trace requestTrace, wantURL, result string) {
+	t.Helper()
+	if trace.Method != http.MethodGet || trace.URL != wantURL || trace.Status != http.StatusOK {
+		t.Fatalf("unexpected %s %s trace: %+v, want GET %s status 200", provider, operation, trace, wantURL)
+	}
+	t.Logf("TRACE provider=%s operation=%s method=%s url=%s status=%d result=%s", provider, operation, trace.Method, trace.URL, trace.Status, result)
+}
+
+func TestProviderRequestTraces(t *testing.T) {
+	t.Run("google finance", func(t *testing.T) {
+		transport := &recordingTransport{handler: func(request *http.Request) (*http.Response, error) {
+			switch request.URL.Path {
+			case "/finance/":
+				return traceResponse(http.StatusOK, "Google Finance")
+			case "/finance/quote/AAPL:NASDAQ":
+				return traceResponse(http.StatusOK, googleFinanceFixture)
+			default:
+				return nil, fmt.Errorf("unexpected Google Finance path: %s", request.URL.Path)
+			}
+		}}
+		provider := newGoogleFinanceProviderForTest(&http.Client{Transport: transport}, "http://google.test", "NASDAQ")
+
+		quote, err := provider.GetQuote(context.Background(), "AAPL:NASDAQ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertAndLogTrace(t, "google_finance", "quote", transport.calls[0], "http://google.test/finance/quote/AAPL:NASDAQ?hl=en", "price:189.42")
+		if quote.Price != 189.42 {
+			t.Fatalf("unexpected quote: %+v", quote)
+		}
+
+		details, err := provider.GetTickerDetails(context.Background(), "AAPL:NASDAQ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertAndLogTrace(t, "google_finance", "details", transport.calls[1], "http://google.test/finance/quote/AAPL:NASDAQ?hl=en", "symbol:AAPL")
+		if details.Name != "Apple Inc" {
+			t.Fatalf("unexpected details: %+v", details)
+		}
+
+		if err := provider.ValidateConnection(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		assertAndLogTrace(t, "google_finance", "validate_connection", transport.calls[2], "http://google.test/finance/?hl=en", "connected")
+
+		before := len(transport.calls)
+		if _, err := provider.GetDividends(context.Background(), "AAPL", 1); err != errGoogleFinanceDividendsUnsupported {
+			t.Fatalf("expected unsupported dividends error, got %v", err)
+		}
+		if len(transport.calls) != before {
+			t.Fatal("Google Finance dividends must not make an HTTP request")
+		}
+	})
+
+	t.Run("yfinance", func(t *testing.T) {
+		transport := &recordingTransport{handler: func(request *http.Request) (*http.Response, error) {
+			if request.URL.Path != "/v8/finance/chart/AAPL" {
+				return nil, fmt.Errorf("unexpected Yahoo Finance path: %s", request.URL.Path)
+			}
+			return traceResponse(http.StatusOK, yahooChartFixture)
+		}}
+		provider := newYFinanceProviderForTest(&http.Client{Transport: transport}, "http://yahoo.test")
+
+		quote, err := provider.GetQuote(context.Background(), "AAPL")
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertAndLogTrace(t, "yfinance", "quote", transport.calls[0], "http://yahoo.test/v8/finance/chart/AAPL?events=div%2Csplits&interval=1d&range=5d", "price:189.42")
+		if quote.Price != 189.42 {
+			t.Fatalf("unexpected quote: %+v", quote)
+		}
+
+		if _, err := provider.GetTickerDetails(context.Background(), "AAPL"); err != nil {
+			t.Fatal(err)
+		}
+		assertAndLogTrace(t, "yfinance", "details", transport.calls[1], "http://yahoo.test/v8/finance/chart/AAPL?events=div%2Csplits&interval=1d&range=5d", "symbol:AAPL")
+
+		dividends, err := provider.GetDividends(context.Background(), "AAPL", 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertAndLogTrace(t, "yfinance", "dividends", transport.calls[2], "http://yahoo.test/v8/finance/chart/AAPL?events=div%2Csplits&interval=1d&range=10y", "count:1")
+		if len(dividends) != 1 {
+			t.Fatalf("unexpected dividends: %+v", dividends)
+		}
+
+		if err := provider.ValidateConnection(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		assertAndLogTrace(t, "yfinance", "validate_connection", transport.calls[3], "http://yahoo.test/v8/finance/chart/AAPL?events=div%2Csplits&interval=1d&range=5d", "connected")
+	})
+
+	t.Run("polygon", func(t *testing.T) {
+		transport := &recordingTransport{handler: func(request *http.Request) (*http.Response, error) {
+			switch request.URL.Path {
+			case "/v2/aggs/ticker/AAPL/prev":
+				return traceResponse(http.StatusOK, `{"status":"OK","results":[{"T":"AAPL","c":189.42,"h":190,"l":187,"o":188,"v":123,"t":1724328000000}]}`)
+			case "/v3/reference/tickers/AAPL":
+				return traceResponse(http.StatusOK, `{"status":"OK","results":{"ticker":"AAPL","name":"Apple Inc.","market":"stocks","type":"CS","active":true,"currency_name":"USD"}}`)
+			case "/v3/reference/dividends":
+				return traceResponse(http.StatusOK, `{"status":"OK","results":[{"ticker":"AAPL","cash_amount":0.25,"ex_dividend_date":"2024-08-13"}]}`)
+			case "/v1/marketstatus/now":
+				return traceResponse(http.StatusOK, `{}`)
+			default:
+				return nil, fmt.Errorf("unexpected Polygon path: %s", request.URL.Path)
+			}
+		}}
+		client := polygon.NewClientWithBaseURL("secret-key", "http://polygon.test", &http.Client{Transport: transport})
+		provider := newPolygonProviderForTest(client)
+
+		quote, err := provider.GetQuote(context.Background(), "AAPL")
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertAndLogTrace(t, "polygon", "quote", transport.calls[0], "http://polygon.test/v2/aggs/ticker/AAPL/prev?adjusted=true&apikey=REDACTED", "price:189.42")
+		if quote.Price != 189.42 {
+			t.Fatalf("unexpected quote: %+v", quote)
+		}
+
+		if _, err := provider.GetTickerDetails(context.Background(), "AAPL"); err != nil {
+			t.Fatal(err)
+		}
+		assertAndLogTrace(t, "polygon", "details", transport.calls[1], "http://polygon.test/v3/reference/tickers/AAPL?apikey=REDACTED", "symbol:AAPL")
+
+		dividends, err := provider.GetDividends(context.Background(), "AAPL", 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertAndLogTrace(t, "polygon", "dividends", transport.calls[2], "http://polygon.test/v3/reference/dividends?apikey=REDACTED&limit=1&ticker=AAPL", "count:1")
+		if len(dividends) != 1 {
+			t.Fatalf("unexpected dividends: %+v", dividends)
+		}
+
+		if err := provider.ValidateConnection(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		assertAndLogTrace(t, "polygon", "validate_connection", transport.calls[3], "http://polygon.test/v1/marketstatus/now?apikey=REDACTED", "connected")
+	})
+}
+
+func TestProviderMarketRequestPaths(t *testing.T) {
+	tests := []struct {
+		name, googleSymbol, yahooSymbol, googlePath, yahooPath string
+	}{
+		{"NASDAQ", "AAPL:NASDAQ", "AAPL", "/finance/quote/AAPL:NASDAQ", "/v8/finance/chart/AAPL"},
+		{"NYSE", "IBM:NYSE", "IBM", "/finance/quote/IBM:NYSE", "/v8/finance/chart/IBM"},
+		{"NYSEARCA", "SPY:NYSEARCA", "SPY", "/finance/quote/SPY:NYSEARCA", "/v8/finance/chart/SPY"},
+		{"BVMF", "PETR4:BVMF", "PETR4.SA", "/finance/quote/PETR4:BVMF", "/v8/finance/chart/PETR4.SA"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			googleTransport := &recordingTransport{handler: func(request *http.Request) (*http.Response, error) {
+				if request.URL.Path != tt.googlePath {
+					return nil, fmt.Errorf("Google path = %s, want %s", request.URL.Path, tt.googlePath)
+				}
+				return traceResponse(http.StatusOK, googleFinanceFixture)
+			}}
+			google := newGoogleFinanceProviderForTest(&http.Client{Transport: googleTransport}, "http://google.test", "")
+			if _, err := google.GetQuote(context.Background(), tt.googleSymbol); err != nil {
+				t.Fatal(err)
+			}
+			assertAndLogTrace(t, "google_finance", "quote", googleTransport.calls[0], "http://google.test"+tt.googlePath+"?hl=en", "market:"+tt.name)
+
+			yahooTransport := &recordingTransport{handler: func(request *http.Request) (*http.Response, error) {
+				if request.URL.Path != tt.yahooPath {
+					return nil, fmt.Errorf("Yahoo path = %s, want %s", request.URL.Path, tt.yahooPath)
+				}
+				return traceResponse(http.StatusOK, yahooChartFixture)
+			}}
+			yahoo := newYFinanceProviderForTest(&http.Client{Transport: yahooTransport}, "http://yahoo.test")
+			if _, err := yahoo.GetQuote(context.Background(), tt.yahooSymbol); err != nil {
+				t.Fatal(err)
+			}
+			assertAndLogTrace(t, "yfinance", "quote", yahooTransport.calls[0], "http://yahoo.test"+tt.yahooPath+"?events=div%2Csplits&interval=1d&range=5d", "market:"+tt.name)
+		})
+	}
+}

--- a/internal/providers/service.go
+++ b/internal/providers/service.go
@@ -31,7 +31,7 @@ func (s *Service) getProvider() (Provider, error) {
 	if providerType == "" {
 		providerType = "polygon"
 	}
-	providerType = strings.ToLower(providerType)
+	providerType = strings.ToLower(strings.TrimSpace(providerType))
 
 	switch providerType {
 	case "polygon":
@@ -48,7 +48,7 @@ func (s *Service) getProvider() (Provider, error) {
 			} else {
 				maskedKey = "***"
 			}
-			log.Printf("[PROVIDER] Using %s provider with API key: %s", strings.ToUpper(providerType), maskedKey)
+			log.Printf("[PROVIDER] Using %s provider with API key: %s (DEBUG_PROVIDERS=1 - do not enable in production)", strings.ToUpper(providerType), maskedKey)
 		}
 
 		return NewPolygonProvider(apiKey), nil
@@ -125,8 +125,16 @@ func (s *Service) UpdateAllSymbolPrices(ctx context.Context) error {
 			updated++
 		}
 
-		// Rate limiting to respect provider API limits
-		time.Sleep(rateLimitDelay)
+		// Rate limiting to respect provider API limits, while honoring context cancellation
+		if rateLimitDelay > 0 {
+			select {
+			case <-ctx.Done():
+				log.Printf("[PROVIDER] Prioritized bulk price update canceled during rate limiting: %v", ctx.Err())
+				return ctx.Err()
+			case <-time.After(rateLimitDelay):
+				// continue to next symbol
+			}
+		}
 	}
 
 	log.Printf("[PROVIDER] Prioritized bulk price update complete: %d updated, %d failed", updated, failed)
@@ -268,13 +276,9 @@ func (s *Service) Name() string {
 		providerType = "polygon"
 	}
 
-	switch providerType {
-	case "polygon":
-		return "Polygon.io"
-	default:
-		return strings.Title(providerType)
-	}
+	return providerType
 }
+
 
 // GetRateLimitDelay returns the rate limit delay based on the configured provider
 func (s *Service) GetRateLimitDelay() time.Duration {

--- a/internal/providers/service.go
+++ b/internal/providers/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"stonks/internal/models"
 	"strings"
 	"time"
@@ -11,7 +12,6 @@ import (
 
 // Service provides market data integration for Wheeler using provider abstraction
 type Service struct {
-	provider       Provider
 	symbolService  *models.SymbolService
 	settingService *models.SettingService
 }
@@ -40,14 +40,16 @@ func (s *Service) getProvider() (Provider, error) {
 			return nil, fmt.Errorf("Polygon API key not configured - please set your API key in Settings")
 		}
 
-		// Log masked API key for debugging
-		var maskedKey string
-		if len(apiKey) > 6 {
-			maskedKey = apiKey[:3] + "..." + apiKey[len(apiKey)-3:]
-		} else {
-			maskedKey = "***"
+		// Optionally log masked API key for debugging when DEBUG_PROVIDERS is enabled
+		if os.Getenv("DEBUG_PROVIDERS") == "1" {
+			var maskedKey string
+			if len(apiKey) > 6 {
+				maskedKey = apiKey[:3] + "..." + apiKey[len(apiKey)-3:]
+			} else {
+				maskedKey = "***"
+			}
+			log.Printf("[PROVIDER] Using %s provider with API key: %s", strings.ToUpper(providerType), maskedKey)
 		}
-		log.Printf("[PROVIDER] Using %s provider with API key: %s", strings.ToUpper(providerType), maskedKey)
 
 		return NewPolygonProvider(apiKey), nil
 	default:
@@ -62,6 +64,11 @@ func (s *Service) UpdateSymbolPrice(ctx context.Context, symbol string) error {
 		return fmt.Errorf("failed to get provider: %w", err)
 	}
 
+	return s.updateSymbolPriceWithProvider(ctx, provider, symbol)
+}
+
+// updateSymbolPriceWithProvider updates a single symbol's price using a pre-fetched provider
+func (s *Service) updateSymbolPriceWithProvider(ctx context.Context, provider Provider, symbol string) error {
 	log.Printf("[PROVIDER] Updating price for symbol: %s using %s", symbol, provider.Name())
 
 	// Get current price from provider
@@ -106,17 +113,20 @@ func (s *Service) UpdateAllSymbolPrices(ctx context.Context) error {
 
 	log.Printf("[PROVIDER] Starting prioritized bulk price update for %d symbols using %s", len(symbols), provider.Name())
 
+	// Get rate limit configuration from provider (or use default)
+	rateLimitDelay := s.GetRateLimitDelay()
+
 	var updated, failed int
 	for _, symbol := range symbols {
-		if err := s.UpdateSymbolPrice(ctx, symbol); err != nil {
+		if err := s.updateSymbolPriceWithProvider(ctx, provider, symbol); err != nil {
 			log.Printf("[PROVIDER] Failed to update %s: %v", symbol, err)
 			failed++
 		} else {
 			updated++
 		}
 
-		// Rate limiting: Polygon.io Free tier allows 5 requests per minute (approx. 1 request every 12 seconds)
-		time.Sleep(12 * time.Second)
+		// Rate limiting to respect provider API limits
+		time.Sleep(rateLimitDelay)
 	}
 
 	log.Printf("[PROVIDER] Prioritized bulk price update complete: %d updated, %d failed", updated, failed)
@@ -211,22 +221,61 @@ func (s *Service) TestConnection(ctx context.Context) error {
 
 // GetAPIKeyStatus returns information about the current API key configuration
 func (s *Service) GetAPIKeyStatus() *APIKeyStatus {
-	apiKey := s.settingService.GetValue("POLYGON_API_KEY")
-	
+	providerType := strings.ToLower(strings.TrimSpace(s.settingService.GetValue("DATA_PROVIDER_TYPE")))
+	if providerType == "" {
+		providerType = "polygon" // Default to Polygon for backwards compatibility
+	}
+
+	var apiKey string
+
+	switch providerType {
+	case "polygon":
+		apiKey = s.settingService.GetValue("POLYGON_API_KEY")
+		// Add additional providers here as they are supported, for example:
+		// case "alpaca":
+		//     apiKey = s.settingService.GetValue("ALPACA_API_KEY")
+	default:
+		// Unknown or unsupported provider type; report as not configured
+		return &APIKeyStatus{
+			Configured: false,
+			Masked:     "",
+		}
+	}
+
 	status := &APIKeyStatus{
 		Configured: apiKey != "",
 		Masked:     "",
 	}
 
-	if status.Configured {
-		if len(apiKey) > 6 {
-			status.Masked = apiKey[:3] + "..." + apiKey[len(apiKey)-3:]
-		} else {
-			status.Masked = strings.Repeat("*", len(apiKey))
-		}
+	if !status.Configured {
+		return status
+	}
+
+	// Mask the API key so only a small portion is visible
+	if len(apiKey) > 6 {
+		status.Masked = apiKey[:3] + "..." + apiKey[len(apiKey)-3:]
+	} else {
+		status.Masked = strings.Repeat("*", len(apiKey))
 	}
 
 	return status
+}
+
+// getRateLimitDelay returns the rate limit delay based on the configured provider
+func (s *Service) GetRateLimitDelay() time.Duration {
+	providerType := strings.ToLower(strings.TrimSpace(s.settingService.GetValue("DATA_PROVIDER_TYPE")))
+	if providerType == "" {
+		providerType = "polygon"
+	}
+
+	switch providerType {
+	case "polygon":
+		// Polygon.io Free tier allows 5 requests per minute (approx. 1 request every 12 seconds)
+		return 12 * time.Second
+	default:
+		// Conservative default for unknown providers
+		return 10 * time.Second
+	}
 }
 
 // SymbolInfo represents enriched symbol information from a provider

--- a/internal/providers/service.go
+++ b/internal/providers/service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"stonks/internal/markets"
 	"stonks/internal/models"
 	"strings"
 	"time"
@@ -20,20 +21,65 @@ const (
 	providerTypePolygon  = "polygon"
 	providerTypeGoogle   = "google_finance"
 	providerTypeYFinance = "yfinance"
+	// bulkPriceUpdateLimit keeps Polygon's 12-second free-tier pacing safely
+	// within the five-minute web request deadline. The remainder is reported
+	// to callers so it can be refreshed in a later request.
+	bulkPriceUpdateLimit = 20
 )
 
-// normalizeProviderType keeps user-facing aliases in one place and returns
-// the canonical identifier used by provider selection, status, and throttling.
-func normalizeProviderType(raw string) string {
+// ProviderProfile describes the configuration and capabilities of a market
+// data provider. Provider IDs are stored per database in DATA_PROVIDER_TYPE.
+type ProviderProfile struct {
+	ID                string        `json:"id"`
+	DisplayName       string        `json:"display_name"`
+	RequiresAPIKey    bool          `json:"requires_api_key"`
+	SupportsDividends bool          `json:"supports_dividends"`
+	RateLimitDelay    time.Duration `json:"-"`
+}
+
+var providerProfiles = map[string]ProviderProfile{
+	providerTypePolygon: {
+		ID: providerTypePolygon, DisplayName: "Polygon.io", RequiresAPIKey: true,
+		SupportsDividends: true, RateLimitDelay: 12 * time.Second,
+	},
+	providerTypeGoogle: {
+		ID: providerTypeGoogle, DisplayName: "Google Finance",
+		SupportsDividends: false, RateLimitDelay: 2 * time.Second,
+	},
+	providerTypeYFinance: {
+		ID: providerTypeYFinance, DisplayName: "Yahoo Finance (yfinance)",
+		SupportsDividends: true, RateLimitDelay: 2 * time.Second,
+	},
+}
+
+// CanonicalProviderType normalizes supported aliases. The empty value keeps
+// the historical default of Polygon. Unsupported values return ok=false.
+func CanonicalProviderType(raw string) (providerType string, ok bool) {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case "", providerTypePolygon:
-		return providerTypePolygon
+		return providerTypePolygon, true
 	case "google", "googlefinance", providerTypeGoogle:
-		return providerTypeGoogle
+		return providerTypeGoogle, true
 	case "yahoo", "yahoo_finance", providerTypeYFinance:
-		return providerTypeYFinance
+		return providerTypeYFinance, true
 	default:
-		return strings.ToLower(strings.TrimSpace(raw))
+		return "", false
+	}
+}
+
+func normalizeProviderType(raw string) string {
+	if providerType, ok := CanonicalProviderType(raw); ok {
+		return providerType
+	}
+	return strings.ToLower(strings.TrimSpace(raw))
+}
+
+// ProviderProfiles returns the supported profiles in stable UI order.
+func ProviderProfiles() []ProviderProfile {
+	return []ProviderProfile{
+		providerProfiles[providerTypePolygon],
+		providerProfiles[providerTypeGoogle],
+		providerProfiles[providerTypeYFinance],
 	}
 }
 
@@ -41,6 +87,7 @@ func normalizeProviderType(raw string) string {
 type BulkPriceUpdateResult struct {
 	Updated int
 	Failed  int
+	Skipped int
 	Errors  []string
 }
 
@@ -90,11 +137,7 @@ func (s *Service) getProvider() (Provider, error) {
 
 		return NewPolygonProvider(apiKey), nil
 	case providerTypeGoogle:
-		exchange := strings.ToUpper(strings.TrimSpace(s.settingService.GetValue("GOOGLE_FINANCE_EXCHANGE")))
-		if exchange == "" {
-			exchange = "NASDAQ"
-		}
-		return NewGoogleFinanceProvider(exchange), nil
+		return NewGoogleFinanceProvider(""), nil
 	case providerTypeYFinance:
 		return NewYFinanceProvider(), nil
 	default:
@@ -102,22 +145,44 @@ func (s *Service) getProvider() (Provider, error) {
 	}
 }
 
+func (s *Service) providerType() string {
+	return normalizeProviderType(s.settingService.GetValue("DATA_PROVIDER_TYPE"))
+}
+
+func (s *Service) resolveProviderSymbol(symbol string) (string, error) {
+	instrument, err := markets.Parse(symbol)
+	if err != nil {
+		return "", err
+	}
+	return markets.ProviderSymbol(s.providerType(), instrument)
+}
+
+// ActiveProfile returns the current provider profile. Unsupported persisted
+// values return a zero profile so callers can report configuration errors.
+func (s *Service) ActiveProfile() ProviderProfile {
+	return providerProfiles[normalizeProviderType(s.settingService.GetValue("DATA_PROVIDER_TYPE"))]
+}
+
 // UpdateSymbolPrice updates a single symbol's price from the configured provider
 func (s *Service) UpdateSymbolPrice(ctx context.Context, symbol string) error {
+	providerSymbol, err := s.resolveProviderSymbol(symbol)
+	if err != nil {
+		return err
+	}
 	provider, err := s.getProvider()
 	if err != nil {
 		return fmt.Errorf("failed to get provider: %w", err)
 	}
 
-	return s.updateSymbolPriceWithProvider(ctx, provider, symbol)
+	return s.updateSymbolPriceWithProvider(ctx, provider, symbol, providerSymbol)
 }
 
 // updateSymbolPriceWithProvider updates a single symbol's price using a pre-fetched provider
-func (s *Service) updateSymbolPriceWithProvider(ctx context.Context, provider Provider, symbol string) error {
+func (s *Service) updateSymbolPriceWithProvider(ctx context.Context, provider Provider, symbol, providerSymbol string) error {
 	log.Printf("[PROVIDER] Updating price for symbol: %s using %s", symbol, provider.Name())
 
 	// Get current price from provider
-	quote, err := provider.GetQuote(ctx, symbol)
+	quote, err := provider.GetQuote(ctx, providerSymbol)
 	if err != nil {
 		return fmt.Errorf("failed to get quote for %s: %w", symbol, err)
 	}
@@ -179,24 +244,28 @@ func (s *Service) UpdateSymbolPrices(ctx context.Context, symbols []string) (*Bu
 
 // FetchSymbolDetails gets detailed information about a symbol from the provider
 func (s *Service) FetchSymbolDetails(ctx context.Context, symbol string) (*SymbolInfo, error) {
+	providerSymbol, err := s.resolveProviderSymbol(symbol)
+	if err != nil {
+		return nil, err
+	}
 	provider, err := s.getProvider()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get provider: %w", err)
 	}
 
-	details, err := provider.GetTickerDetails(ctx, symbol)
+	details, err := provider.GetTickerDetails(ctx, providerSymbol)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get ticker details: %w", err)
 	}
 
-	quote, err := provider.GetQuote(ctx, symbol)
+	quote, err := provider.GetQuote(ctx, providerSymbol)
 	if err != nil {
 		log.Printf("[PROVIDER] Warning: failed to get current price for %s: %v", symbol, err)
 		// Continue without current price
 	}
 
 	info := &SymbolInfo{
-		Symbol:      details.Symbol,
+		Symbol:      symbol,
 		Name:        details.Name,
 		Market:      details.Market,
 		Type:        details.Type,
@@ -221,6 +290,10 @@ func (s *Service) FetchSymbolDetails(ctx context.Context, symbol string) (*Symbo
 
 // FetchDividendHistory gets recent dividend history for a symbol
 func (s *Service) FetchDividendHistory(ctx context.Context, symbol string, limit int) ([]*DividendInfo, error) {
+	providerSymbol, err := s.resolveProviderSymbol(symbol)
+	if err != nil {
+		return nil, err
+	}
 	provider, err := s.getProvider()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get provider: %w", err)
@@ -230,7 +303,7 @@ func (s *Service) FetchDividendHistory(ctx context.Context, symbol string, limit
 		limit = 10
 	}
 
-	dividends, err := provider.GetDividends(ctx, symbol, limit)
+	dividends, err := provider.GetDividends(ctx, providerSymbol, limit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get dividends: %w", err)
 	}
@@ -258,9 +331,21 @@ func (s *Service) FetchDividendHistoryForSymbols(ctx context.Context, symbols []
 	rateLimitDelay := s.GetRateLimitDelay()
 	result := &BulkDividendFetchResult{Results: []DividendFetchRecord{}}
 
-	for idx, symbol := range normalized {
+	providerCalls := 0
+	for _, symbol := range normalized {
 		result.Processed++
-		dividends, fetchErr := provider.GetDividends(ctx, symbol, limit)
+		providerSymbol, resolveErr := s.resolveProviderSymbol(symbol)
+		if resolveErr != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("%s: %v", symbol, resolveErr))
+			continue
+		}
+		if providerCalls > 0 {
+			if err := s.waitForRateLimit(ctx, rateLimitDelay); err != nil {
+				return result, err
+			}
+		}
+		dividends, fetchErr := provider.GetDividends(ctx, providerSymbol, limit)
+		providerCalls++
 		if fetchErr != nil {
 			log.Printf("[PROVIDER] Failed to fetch dividends for %s: %v", symbol, fetchErr)
 			result.Errors = append(result.Errors, fmt.Sprintf("%s: %v", symbol, fetchErr))
@@ -271,11 +356,6 @@ func (s *Service) FetchDividendHistoryForSymbols(ctx context.Context, symbols []
 			})
 		}
 
-		if idx < len(normalized)-1 {
-			if err := s.waitForRateLimit(ctx, rateLimitDelay); err != nil {
-				return result, err
-			}
-		}
 	}
 
 	log.Printf("[PROVIDER] Dividend fetch complete: %d symbols processed", result.Processed)
@@ -295,6 +375,10 @@ func (s *Service) TestConnection(ctx context.Context) error {
 // GetAPIKeyStatus returns information about the current API key configuration
 func (s *Service) GetAPIKeyStatus() *APIKeyStatus {
 	providerType := normalizeProviderType(s.settingService.GetValue("DATA_PROVIDER_TYPE"))
+	profile, supported := providerProfiles[providerType]
+	if !supported {
+		return &APIKeyStatus{Provider: providerType}
+	}
 
 	var apiKey string
 
@@ -302,21 +386,25 @@ func (s *Service) GetAPIKeyStatus() *APIKeyStatus {
 	case providerTypePolygon:
 		apiKey = s.settingService.GetValue("POLYGON_API_KEY")
 	case providerTypeGoogle, providerTypeYFinance:
-		return &APIKeyStatus{Configured: true, Masked: "Not required", Valid: true}
-		// Add additional providers here as they are supported, for example:
-		// case "alpaca":
-		//     apiKey = s.settingService.GetValue("ALPACA_API_KEY")
-	default:
-		// Unknown or unsupported provider type; report as not configured
 		return &APIKeyStatus{
-			Configured: false,
-			Masked:     "",
+			Provider:          profile.ID,
+			DisplayName:       profile.DisplayName,
+			RequiresAPIKey:    false,
+			SupportsDividends: profile.SupportsDividends,
+			Configured:        false,
+			Ready:             true,
+			Masked:            "Not required",
 		}
 	}
 
 	status := &APIKeyStatus{
-		Configured: apiKey != "",
-		Masked:     "",
+		Provider:          profile.ID,
+		DisplayName:       profile.DisplayName,
+		RequiresAPIKey:    profile.RequiresAPIKey,
+		SupportsDividends: profile.SupportsDividends,
+		Configured:        apiKey != "",
+		Ready:             apiKey != "",
+		Masked:            "",
 	}
 
 	if !status.Configured {
@@ -340,20 +428,10 @@ func (s *Service) Name() string {
 
 // GetRateLimitDelay returns the rate limit delay based on the configured provider
 func (s *Service) GetRateLimitDelay() time.Duration {
-	providerType := normalizeProviderType(s.settingService.GetValue("DATA_PROVIDER_TYPE"))
-
-	switch providerType {
-	case providerTypePolygon:
-		// Polygon.io Free tier allows 5 requests per minute (approx. 1 request every 12 seconds)
-		return 12 * time.Second
-	case providerTypeGoogle:
-		return 2 * time.Second
-	case providerTypeYFinance:
-		return 2 * time.Second
-	default:
-		// Conservative default for unknown providers
-		return 10 * time.Second
+	if profile := s.ActiveProfile(); profile.ID != "" {
+		return profile.RateLimitDelay
 	}
+	return 10 * time.Second
 }
 
 // SymbolInfo represents enriched symbol information from a provider
@@ -389,30 +467,47 @@ type DividendInfo struct {
 
 // APIKeyStatus represents the status of the provider API key
 type APIKeyStatus struct {
-	Configured bool   `json:"configured"`
-	Masked     string `json:"masked"`
-	Valid      bool   `json:"valid"`
-	Error      string `json:"error,omitempty"`
+	Provider          string `json:"provider"`
+	DisplayName       string `json:"display_name"`
+	RequiresAPIKey    bool   `json:"requires_api_key"`
+	SupportsDividends bool   `json:"supports_dividends"`
+	Configured        bool   `json:"configured"`
+	Ready             bool   `json:"ready"`
+	Masked            string `json:"masked"`
+	Valid             bool   `json:"valid"`
+	Error             string `json:"error,omitempty"`
 }
 
 func (s *Service) runPriceUpdates(ctx context.Context, provider Provider, symbols []string) (*BulkPriceUpdateResult, error) {
 	rateLimitDelay := s.GetRateLimitDelay()
 	result := &BulkPriceUpdateResult{}
+	if len(symbols) > bulkPriceUpdateLimit {
+		result.Skipped = len(symbols) - bulkPriceUpdateLimit
+		symbols = symbols[:bulkPriceUpdateLimit]
+		log.Printf("[PROVIDER] Limiting this bulk price update to %d symbols; %d remaining", len(symbols), result.Skipped)
+	}
 
-	for idx, symbol := range symbols {
-		if err := s.updateSymbolPriceWithProvider(ctx, provider, symbol); err != nil {
+	providerCalls := 0
+	for _, symbol := range symbols {
+		providerSymbol, resolveErr := s.resolveProviderSymbol(symbol)
+		if resolveErr != nil {
+			result.Failed++
+			result.Errors = append(result.Errors, fmt.Sprintf("%s: %v", symbol, resolveErr))
+			continue
+		}
+		if providerCalls > 0 {
+			if err := s.waitForRateLimit(ctx, rateLimitDelay); err != nil {
+				return result, err
+			}
+		}
+		if err := s.updateSymbolPriceWithProvider(ctx, provider, symbol, providerSymbol); err != nil {
 			result.Failed++
 			result.Errors = append(result.Errors, fmt.Sprintf("%s: %v", symbol, err))
 			log.Printf("[PROVIDER] Failed to update %s: %v", symbol, err)
 		} else {
 			result.Updated++
 		}
-
-		if idx < len(symbols)-1 {
-			if err := s.waitForRateLimit(ctx, rateLimitDelay); err != nil {
-				return result, err
-			}
-		}
+		providerCalls++
 	}
 
 	return result, nil
@@ -453,6 +548,9 @@ func (s *Service) normalizeSymbols(symbols []string) []string {
 func convertDividendsToInfo(dividends []*Dividend) []*DividendInfo {
 	result := make([]*DividendInfo, 0, len(dividends))
 	for _, div := range dividends {
+		if div == nil {
+			continue
+		}
 		result = append(result, &DividendInfo{
 			Symbol:          div.Symbol,
 			CashAmount:      div.CashAmount,

--- a/internal/providers/service.go
+++ b/internal/providers/service.go
@@ -279,7 +279,6 @@ func (s *Service) Name() string {
 	return providerType
 }
 
-
 // GetRateLimitDelay returns the rate limit delay based on the configured provider
 func (s *Service) GetRateLimitDelay() time.Duration {
 	providerType := strings.ToLower(strings.TrimSpace(s.settingService.GetValue("DATA_PROVIDER_TYPE")))

--- a/internal/providers/service.go
+++ b/internal/providers/service.go
@@ -27,6 +27,12 @@ const (
 	bulkPriceUpdateLimit = 20
 )
 
+// BulkPriceUpdateLimit is the maximum number of symbols processed by one bulk
+// price request. Callers can use it to explain why a later request is needed.
+func BulkPriceUpdateLimit() int {
+	return bulkPriceUpdateLimit
+}
+
 // ProviderProfile describes the configuration and capabilities of a market
 // data provider. Provider IDs are stored per database in DATA_PROVIDER_TYPE.
 type ProviderProfile struct {
@@ -100,6 +106,7 @@ type DividendFetchRecord struct {
 // BulkDividendFetchResult summarizes dividend history fetches across many symbols
 type BulkDividendFetchResult struct {
 	Processed int
+	Skipped   int
 	Results   []DividendFetchRecord
 	Errors    []string
 }
@@ -330,6 +337,11 @@ func (s *Service) FetchDividendHistoryForSymbols(ctx context.Context, symbols []
 	log.Printf("[PROVIDER] Starting dividend fetch for %d symbols using %s", len(normalized), provider.Name())
 	rateLimitDelay := s.GetRateLimitDelay()
 	result := &BulkDividendFetchResult{Results: []DividendFetchRecord{}}
+	if len(normalized) > bulkPriceUpdateLimit {
+		result.Skipped = len(normalized) - bulkPriceUpdateLimit
+		normalized = normalized[:bulkPriceUpdateLimit]
+		log.Printf("[PROVIDER] Limiting this dividend fetch to %d symbols; %d remaining", len(normalized), result.Skipped)
+	}
 
 	providerCalls := 0
 	for _, symbol := range normalized {

--- a/internal/providers/service.go
+++ b/internal/providers/service.go
@@ -1,0 +1,257 @@
+package providers
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"stonks/internal/models"
+	"strings"
+	"time"
+)
+
+// Service provides market data integration for Wheeler using provider abstraction
+type Service struct {
+	provider       Provider
+	symbolService  *models.SymbolService
+	settingService *models.SettingService
+}
+
+// NewService creates a new provider service with the default provider
+func NewService(symbolService *models.SymbolService, settingService *models.SettingService) *Service {
+	return &Service{
+		symbolService:  symbolService,
+		settingService: settingService,
+	}
+}
+
+// getProvider returns the configured provider with API key
+func (s *Service) getProvider() (Provider, error) {
+	apiKey := s.settingService.GetValue("POLYGON_API_KEY")
+	if apiKey == "" {
+		return nil, fmt.Errorf("Polygon API key not configured - please set your API key in Settings")
+	}
+
+	// Log masked API key for debugging
+	var maskedKey string
+	if len(apiKey) > 6 {
+		maskedKey = apiKey[:3] + "..." + apiKey[len(apiKey)-3:]
+	} else {
+		maskedKey = "***"
+	}
+	log.Printf("[PROVIDER] Using API key: %s", maskedKey)
+
+	return NewPolygonProvider(apiKey), nil
+}
+
+// UpdateSymbolPrice updates a single symbol's price from the configured provider
+func (s *Service) UpdateSymbolPrice(ctx context.Context, symbol string) error {
+	provider, err := s.getProvider()
+	if err != nil {
+		return fmt.Errorf("failed to get provider: %w", err)
+	}
+
+	log.Printf("[PROVIDER] Updating price for symbol: %s using %s", symbol, provider.Name())
+
+	// Get current price from provider
+	quote, err := provider.GetQuote(ctx, symbol)
+	if err != nil {
+		return fmt.Errorf("failed to get quote for %s: %w", symbol, err)
+	}
+
+	// Get current symbol data
+	currentSymbol, err := s.symbolService.GetBySymbol(symbol)
+	if err != nil {
+		return fmt.Errorf("failed to get current symbol data: %w", err)
+	}
+
+	// Update symbol with new price
+	_, err = s.symbolService.Update(
+		symbol,
+		quote.Price,
+		currentSymbol.Dividend,
+		currentSymbol.ExDividendDate,
+		currentSymbol.PERatio,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to update symbol price: %w", err)
+	}
+
+	log.Printf("[PROVIDER] Updated %s price to $%.2f", symbol, quote.Price)
+	return nil
+}
+
+// UpdateAllSymbolPrices updates prices for all symbols in the database
+func (s *Service) UpdateAllSymbolPrices(ctx context.Context) error {
+	symbols, err := s.symbolService.GetPrioritizedSymbols()
+	if err != nil {
+		return fmt.Errorf("failed to get prioritized symbols: %w", err)
+	}
+
+	provider, err := s.getProvider()
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[PROVIDER] Starting prioritized bulk price update for %d symbols using %s", len(symbols), provider.Name())
+
+	var updated, failed int
+	for _, symbol := range symbols {
+		if err := s.UpdateSymbolPrice(ctx, symbol); err != nil {
+			log.Printf("[PROVIDER] Failed to update %s: %v", symbol, err)
+			failed++
+		} else {
+			updated++
+		}
+
+		// Rate limiting: Free tier allows 5 requests per minute
+		time.Sleep(12 * time.Second)
+	}
+
+	log.Printf("[PROVIDER] Prioritized bulk price update complete: %d updated, %d failed", updated, failed)
+	return nil
+}
+
+// FetchSymbolDetails gets detailed information about a symbol from the provider
+func (s *Service) FetchSymbolDetails(ctx context.Context, symbol string) (*SymbolInfo, error) {
+	provider, err := s.getProvider()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get provider: %w", err)
+	}
+
+	details, err := provider.GetTickerDetails(ctx, symbol)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ticker details: %w", err)
+	}
+
+	quote, err := provider.GetQuote(ctx, symbol)
+	if err != nil {
+		log.Printf("[PROVIDER] Warning: failed to get current price for %s: %v", symbol, err)
+		// Continue without current price
+	}
+
+	info := &SymbolInfo{
+		Symbol:      details.Symbol,
+		Name:        details.Name,
+		Market:      details.Market,
+		Type:        details.Type,
+		Active:      details.Active,
+		Currency:    details.Currency,
+		Description: details.Description,
+		Homepage:    details.Homepage,
+		MarketCap:   details.MarketCap,
+		Employees:   details.Employees,
+	}
+
+	if quote != nil {
+		info.CurrentPrice = quote.Price
+		info.PreviousClose = quote.PreviousClose
+		info.High = quote.High
+		info.Low = quote.Low
+		info.Volume = quote.Volume
+	}
+
+	return info, nil
+}
+
+// FetchDividendHistory gets recent dividend history for a symbol
+func (s *Service) FetchDividendHistory(ctx context.Context, symbol string, limit int) ([]*DividendInfo, error) {
+	provider, err := s.getProvider()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get provider: %w", err)
+	}
+
+	if limit <= 0 {
+		limit = 10
+	}
+
+	dividends, err := provider.GetDividends(ctx, symbol, limit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dividends: %w", err)
+	}
+
+	var result []*DividendInfo
+	for _, div := range dividends {
+		info := &DividendInfo{
+			Symbol:          div.Symbol,
+			CashAmount:      div.CashAmount,
+			DeclarationDate: div.DeclarationDate,
+			ExDividendDate:  div.ExDividendDate,
+			PayDate:         div.PayDate,
+			RecordDate:      div.RecordDate,
+			DividendType:    div.DividendType,
+			Frequency:       div.Frequency,
+		}
+		result = append(result, info)
+	}
+
+	return result, nil
+}
+
+// TestConnection validates the provider connection
+func (s *Service) TestConnection(ctx context.Context) error {
+	provider, err := s.getProvider()
+	if err != nil {
+		return err
+	}
+
+	return provider.ValidateConnection(ctx)
+}
+
+// GetAPIKeyStatus returns information about the current API key configuration
+func (s *Service) GetAPIKeyStatus() *APIKeyStatus {
+	apiKey := s.settingService.GetValue("POLYGON_API_KEY")
+	
+	status := &APIKeyStatus{
+		Configured: apiKey != "",
+		Masked:     "",
+	}
+
+	if status.Configured {
+		if len(apiKey) > 6 {
+			status.Masked = apiKey[:3] + "..." + apiKey[len(apiKey)-3:]
+		} else {
+			status.Masked = strings.Repeat("*", len(apiKey))
+		}
+	}
+
+	return status
+}
+
+// SymbolInfo represents enriched symbol information from a provider
+type SymbolInfo struct {
+	Symbol        string  `json:"symbol"`
+	Name          string  `json:"name"`
+	Market        string  `json:"market"`
+	Type          string  `json:"type"`
+	Active        bool    `json:"active"`
+	Currency      string  `json:"currency"`
+	Description   string  `json:"description"`
+	Homepage      string  `json:"homepage"`
+	MarketCap     float64 `json:"market_cap"`
+	Employees     int     `json:"employees"`
+	CurrentPrice  float64 `json:"current_price"`
+	PreviousClose float64 `json:"previous_close"`
+	High          float64 `json:"high"`
+	Low           float64 `json:"low"`
+	Volume        float64 `json:"volume"`
+}
+
+// DividendInfo represents dividend information from a provider
+type DividendInfo struct {
+	Symbol          string  `json:"symbol"`
+	CashAmount      float64 `json:"cash_amount"`
+	DeclarationDate string  `json:"declaration_date"`
+	ExDividendDate  string  `json:"ex_dividend_date"`
+	PayDate         string  `json:"pay_date"`
+	RecordDate      string  `json:"record_date"`
+	DividendType    string  `json:"dividend_type"`
+	Frequency       int     `json:"frequency"`
+}
+
+// APIKeyStatus represents the status of the provider API key
+type APIKeyStatus struct {
+	Configured bool   `json:"configured"`
+	Masked     string `json:"masked"`
+	Valid      bool   `json:"valid"`
+	Error      string `json:"error,omitempty"`
+}

--- a/internal/providers/service.go
+++ b/internal/providers/service.go
@@ -16,6 +16,27 @@ type Service struct {
 	settingService *models.SettingService
 }
 
+const (
+	providerTypePolygon  = "polygon"
+	providerTypeGoogle   = "google_finance"
+	providerTypeYFinance = "yfinance"
+)
+
+// normalizeProviderType keeps user-facing aliases in one place and returns
+// the canonical identifier used by provider selection, status, and throttling.
+func normalizeProviderType(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", providerTypePolygon:
+		return providerTypePolygon
+	case "google", "googlefinance", providerTypeGoogle:
+		return providerTypeGoogle
+	case "yahoo", "yahoo_finance", providerTypeYFinance:
+		return providerTypeYFinance
+	default:
+		return strings.ToLower(strings.TrimSpace(raw))
+	}
+}
+
 // BulkPriceUpdateResult captures aggregate information from a bulk price update run
 type BulkPriceUpdateResult struct {
 	Updated int
@@ -47,14 +68,10 @@ func NewService(symbolService *models.SymbolService, settingService *models.Sett
 // getProvider returns the configured provider with API key
 func (s *Service) getProvider() (Provider, error) {
 	// Determine which data provider to use, defaulting to Polygon for backwards compatibility
-	providerType := s.settingService.GetValue("DATA_PROVIDER_TYPE")
-	if providerType == "" {
-		providerType = "polygon"
-	}
-	providerType = strings.ToLower(strings.TrimSpace(providerType))
+	providerType := normalizeProviderType(s.settingService.GetValue("DATA_PROVIDER_TYPE"))
 
 	switch providerType {
-	case "polygon":
+	case providerTypePolygon:
 		apiKey := s.settingService.GetValue("POLYGON_API_KEY")
 		if apiKey == "" {
 			return nil, fmt.Errorf("Polygon API key not configured - please set your API key in Settings")
@@ -72,6 +89,14 @@ func (s *Service) getProvider() (Provider, error) {
 		}
 
 		return NewPolygonProvider(apiKey), nil
+	case providerTypeGoogle:
+		exchange := strings.ToUpper(strings.TrimSpace(s.settingService.GetValue("GOOGLE_FINANCE_EXCHANGE")))
+		if exchange == "" {
+			exchange = "NASDAQ"
+		}
+		return NewGoogleFinanceProvider(exchange), nil
+	case providerTypeYFinance:
+		return NewYFinanceProvider(), nil
 	default:
 		return nil, fmt.Errorf("unsupported data provider type: %s", providerType)
 	}
@@ -231,7 +256,7 @@ func (s *Service) FetchDividendHistoryForSymbols(ctx context.Context, symbols []
 
 	log.Printf("[PROVIDER] Starting dividend fetch for %d symbols using %s", len(normalized), provider.Name())
 	rateLimitDelay := s.GetRateLimitDelay()
-	result := &BulkDividendFetchResult{}
+	result := &BulkDividendFetchResult{Results: []DividendFetchRecord{}}
 
 	for idx, symbol := range normalized {
 		result.Processed++
@@ -269,16 +294,15 @@ func (s *Service) TestConnection(ctx context.Context) error {
 
 // GetAPIKeyStatus returns information about the current API key configuration
 func (s *Service) GetAPIKeyStatus() *APIKeyStatus {
-	providerType := strings.ToLower(strings.TrimSpace(s.settingService.GetValue("DATA_PROVIDER_TYPE")))
-	if providerType == "" {
-		providerType = "polygon" // Default to Polygon for backwards compatibility
-	}
+	providerType := normalizeProviderType(s.settingService.GetValue("DATA_PROVIDER_TYPE"))
 
 	var apiKey string
 
 	switch providerType {
-	case "polygon":
+	case providerTypePolygon:
 		apiKey = s.settingService.GetValue("POLYGON_API_KEY")
+	case providerTypeGoogle, providerTypeYFinance:
+		return &APIKeyStatus{Configured: true, Masked: "Not required", Valid: true}
 		// Add additional providers here as they are supported, for example:
 		// case "alpaca":
 		//     apiKey = s.settingService.GetValue("ALPACA_API_KEY")
@@ -311,25 +335,21 @@ func (s *Service) GetAPIKeyStatus() *APIKeyStatus {
 
 // Name returns the name of the configured provider
 func (s *Service) Name() string {
-	providerType := strings.ToLower(strings.TrimSpace(s.settingService.GetValue("DATA_PROVIDER_TYPE")))
-	if providerType == "" {
-		providerType = "polygon"
-	}
-
-	return providerType
+	return normalizeProviderType(s.settingService.GetValue("DATA_PROVIDER_TYPE"))
 }
 
 // GetRateLimitDelay returns the rate limit delay based on the configured provider
 func (s *Service) GetRateLimitDelay() time.Duration {
-	providerType := strings.ToLower(strings.TrimSpace(s.settingService.GetValue("DATA_PROVIDER_TYPE")))
-	if providerType == "" {
-		providerType = "polygon"
-	}
+	providerType := normalizeProviderType(s.settingService.GetValue("DATA_PROVIDER_TYPE"))
 
 	switch providerType {
-	case "polygon":
+	case providerTypePolygon:
 		// Polygon.io Free tier allows 5 requests per minute (approx. 1 request every 12 seconds)
 		return 12 * time.Second
+	case providerTypeGoogle:
+		return 2 * time.Second
+	case providerTypeYFinance:
+		return 2 * time.Second
 	default:
 		// Conservative default for unknown providers
 		return 10 * time.Second

--- a/internal/providers/service.go
+++ b/internal/providers/service.go
@@ -26,21 +26,33 @@ func NewService(symbolService *models.SymbolService, settingService *models.Sett
 
 // getProvider returns the configured provider with API key
 func (s *Service) getProvider() (Provider, error) {
-	apiKey := s.settingService.GetValue("POLYGON_API_KEY")
-	if apiKey == "" {
-		return nil, fmt.Errorf("Polygon API key not configured - please set your API key in Settings")
+	// Determine which data provider to use, defaulting to Polygon for backwards compatibility
+	providerType := s.settingService.GetValue("DATA_PROVIDER_TYPE")
+	if providerType == "" {
+		providerType = "polygon"
 	}
+	providerType = strings.ToLower(providerType)
 
-	// Log masked API key for debugging
-	var maskedKey string
-	if len(apiKey) > 6 {
-		maskedKey = apiKey[:3] + "..." + apiKey[len(apiKey)-3:]
-	} else {
-		maskedKey = "***"
+	switch providerType {
+	case "polygon":
+		apiKey := s.settingService.GetValue("POLYGON_API_KEY")
+		if apiKey == "" {
+			return nil, fmt.Errorf("Polygon API key not configured - please set your API key in Settings")
+		}
+
+		// Log masked API key for debugging
+		var maskedKey string
+		if len(apiKey) > 6 {
+			maskedKey = apiKey[:3] + "..." + apiKey[len(apiKey)-3:]
+		} else {
+			maskedKey = "***"
+		}
+		log.Printf("[PROVIDER] Using %s provider with API key: %s", strings.ToUpper(providerType), maskedKey)
+
+		return NewPolygonProvider(apiKey), nil
+	default:
+		return nil, fmt.Errorf("unsupported data provider type: %s", providerType)
 	}
-	log.Printf("[PROVIDER] Using API key: %s", maskedKey)
-
-	return NewPolygonProvider(apiKey), nil
 }
 
 // UpdateSymbolPrice updates a single symbol's price from the configured provider
@@ -103,7 +115,7 @@ func (s *Service) UpdateAllSymbolPrices(ctx context.Context) error {
 			updated++
 		}
 
-		// Rate limiting: Free tier allows 5 requests per minute
+		// Rate limiting: Polygon.io Free tier allows 5 requests per minute (approx. 1 request every 12 seconds)
 		time.Sleep(12 * time.Second)
 	}
 

--- a/internal/providers/service.go
+++ b/internal/providers/service.go
@@ -261,7 +261,7 @@ func (s *Service) GetAPIKeyStatus() *APIKeyStatus {
 	return status
 }
 
-// getRateLimitDelay returns the rate limit delay based on the configured provider
+// GetRateLimitDelay returns the rate limit delay based on the configured provider
 func (s *Service) GetRateLimitDelay() time.Duration {
 	providerType := strings.ToLower(strings.TrimSpace(s.settingService.GetValue("DATA_PROVIDER_TYPE")))
 	if providerType == "" {

--- a/internal/providers/service.go
+++ b/internal/providers/service.go
@@ -16,6 +16,26 @@ type Service struct {
 	settingService *models.SettingService
 }
 
+// BulkPriceUpdateResult captures aggregate information from a bulk price update run
+type BulkPriceUpdateResult struct {
+	Updated int
+	Failed  int
+	Errors  []string
+}
+
+// DividendFetchRecord captures dividend data returned for a symbol
+type DividendFetchRecord struct {
+	Symbol    string
+	Dividends []*DividendInfo
+}
+
+// BulkDividendFetchResult summarizes dividend history fetches across many symbols
+type BulkDividendFetchResult struct {
+	Processed int
+	Results   []DividendFetchRecord
+	Errors    []string
+}
+
 // NewService creates a new provider service with the default provider
 func NewService(symbolService *models.SymbolService, settingService *models.SettingService) *Service {
 	return &Service{
@@ -100,45 +120,36 @@ func (s *Service) updateSymbolPriceWithProvider(ctx context.Context, provider Pr
 }
 
 // UpdateAllSymbolPrices updates prices for all symbols in the database
-func (s *Service) UpdateAllSymbolPrices(ctx context.Context) error {
+func (s *Service) UpdateAllSymbolPrices(ctx context.Context) (*BulkPriceUpdateResult, error) {
 	symbols, err := s.symbolService.GetPrioritizedSymbols()
 	if err != nil {
-		return fmt.Errorf("failed to get prioritized symbols: %w", err)
+		return nil, fmt.Errorf("failed to get prioritized symbols: %w", err)
+	}
+
+	log.Printf("[PROVIDER] Starting prioritized bulk price update for %d symbols", len(symbols))
+	return s.UpdateSymbolPrices(ctx, symbols)
+}
+
+// UpdateSymbolPrices updates prices for the provided symbol list using a shared provider instance
+func (s *Service) UpdateSymbolPrices(ctx context.Context, symbols []string) (*BulkPriceUpdateResult, error) {
+	normalized := s.normalizeSymbols(symbols)
+	if len(normalized) == 0 {
+		return &BulkPriceUpdateResult{}, nil
 	}
 
 	provider, err := s.getProvider()
 	if err != nil {
-		return err
+		return nil, fmt.Errorf("failed to get provider: %w", err)
 	}
 
-	log.Printf("[PROVIDER] Starting prioritized bulk price update for %d symbols using %s", len(symbols), provider.Name())
-
-	// Get rate limit configuration from provider (or use default)
-	rateLimitDelay := s.GetRateLimitDelay()
-
-	var updated, failed int
-	for _, symbol := range symbols {
-		if err := s.updateSymbolPriceWithProvider(ctx, provider, symbol); err != nil {
-			log.Printf("[PROVIDER] Failed to update %s: %v", symbol, err)
-			failed++
-		} else {
-			updated++
-		}
-
-		// Rate limiting to respect provider API limits, while honoring context cancellation
-		if rateLimitDelay > 0 {
-			select {
-			case <-ctx.Done():
-				log.Printf("[PROVIDER] Prioritized bulk price update canceled during rate limiting: %v", ctx.Err())
-				return ctx.Err()
-			case <-time.After(rateLimitDelay):
-				// continue to next symbol
-			}
-		}
+	log.Printf("[PROVIDER] Starting price update for %d symbols using %s", len(normalized), provider.Name())
+	result, runErr := s.runPriceUpdates(ctx, provider, normalized)
+	if runErr != nil {
+		return result, runErr
 	}
 
-	log.Printf("[PROVIDER] Prioritized bulk price update complete: %d updated, %d failed", updated, failed)
-	return nil
+	log.Printf("[PROVIDER] Price update complete: %d updated, %d failed", result.Updated, result.Failed)
+	return result, nil
 }
 
 // FetchSymbolDetails gets detailed information about a symbol from the provider
@@ -199,21 +210,50 @@ func (s *Service) FetchDividendHistory(ctx context.Context, symbol string, limit
 		return nil, fmt.Errorf("failed to get dividends: %w", err)
 	}
 
-	var result []*DividendInfo
-	for _, div := range dividends {
-		info := &DividendInfo{
-			Symbol:          div.Symbol,
-			CashAmount:      div.CashAmount,
-			DeclarationDate: div.DeclarationDate,
-			ExDividendDate:  div.ExDividendDate,
-			PayDate:         div.PayDate,
-			RecordDate:      div.RecordDate,
-			DividendType:    div.DividendType,
-			Frequency:       div.Frequency,
-		}
-		result = append(result, info)
+	return convertDividendsToInfo(dividends), nil
+}
+
+// FetchDividendHistoryForSymbols fetches dividend history for each provided symbol
+func (s *Service) FetchDividendHistoryForSymbols(ctx context.Context, symbols []string, limit int) (*BulkDividendFetchResult, error) {
+	normalized := s.normalizeSymbols(symbols)
+	if len(normalized) == 0 {
+		return &BulkDividendFetchResult{Results: []DividendFetchRecord{}}, nil
 	}
 
+	if limit <= 0 {
+		limit = 10
+	}
+
+	provider, err := s.getProvider()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get provider: %w", err)
+	}
+
+	log.Printf("[PROVIDER] Starting dividend fetch for %d symbols using %s", len(normalized), provider.Name())
+	rateLimitDelay := s.GetRateLimitDelay()
+	result := &BulkDividendFetchResult{}
+
+	for idx, symbol := range normalized {
+		result.Processed++
+		dividends, fetchErr := provider.GetDividends(ctx, symbol, limit)
+		if fetchErr != nil {
+			log.Printf("[PROVIDER] Failed to fetch dividends for %s: %v", symbol, fetchErr)
+			result.Errors = append(result.Errors, fmt.Sprintf("%s: %v", symbol, fetchErr))
+		} else {
+			result.Results = append(result.Results, DividendFetchRecord{
+				Symbol:    symbol,
+				Dividends: convertDividendsToInfo(dividends),
+			})
+		}
+
+		if idx < len(normalized)-1 {
+			if err := s.waitForRateLimit(ctx, rateLimitDelay); err != nil {
+				return result, err
+			}
+		}
+	}
+
+	log.Printf("[PROVIDER] Dividend fetch complete: %d symbols processed", result.Processed)
 	return result, nil
 }
 
@@ -333,4 +373,76 @@ type APIKeyStatus struct {
 	Masked     string `json:"masked"`
 	Valid      bool   `json:"valid"`
 	Error      string `json:"error,omitempty"`
+}
+
+func (s *Service) runPriceUpdates(ctx context.Context, provider Provider, symbols []string) (*BulkPriceUpdateResult, error) {
+	rateLimitDelay := s.GetRateLimitDelay()
+	result := &BulkPriceUpdateResult{}
+
+	for idx, symbol := range symbols {
+		if err := s.updateSymbolPriceWithProvider(ctx, provider, symbol); err != nil {
+			result.Failed++
+			result.Errors = append(result.Errors, fmt.Sprintf("%s: %v", symbol, err))
+			log.Printf("[PROVIDER] Failed to update %s: %v", symbol, err)
+		} else {
+			result.Updated++
+		}
+
+		if idx < len(symbols)-1 {
+			if err := s.waitForRateLimit(ctx, rateLimitDelay); err != nil {
+				return result, err
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func (s *Service) waitForRateLimit(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return nil
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(delay):
+		return nil
+	}
+}
+
+func (s *Service) normalizeSymbols(symbols []string) []string {
+	seen := make(map[string]struct{})
+	var normalized []string
+
+	for _, raw := range symbols {
+		symbol := strings.ToUpper(strings.TrimSpace(raw))
+		if symbol == "" {
+			continue
+		}
+		if _, exists := seen[symbol]; exists {
+			continue
+		}
+		seen[symbol] = struct{}{}
+		normalized = append(normalized, symbol)
+	}
+
+	return normalized
+}
+
+func convertDividendsToInfo(dividends []*Dividend) []*DividendInfo {
+	result := make([]*DividendInfo, 0, len(dividends))
+	for _, div := range dividends {
+		result = append(result, &DividendInfo{
+			Symbol:          div.Symbol,
+			CashAmount:      div.CashAmount,
+			DeclarationDate: div.DeclarationDate,
+			ExDividendDate:  div.ExDividendDate,
+			PayDate:         div.PayDate,
+			RecordDate:      div.RecordDate,
+			DividendType:    div.DividendType,
+			Frequency:       div.Frequency,
+		})
+	}
+	return result
 }

--- a/internal/providers/service.go
+++ b/internal/providers/service.go
@@ -261,6 +261,21 @@ func (s *Service) GetAPIKeyStatus() *APIKeyStatus {
 	return status
 }
 
+// Name returns the name of the configured provider
+func (s *Service) Name() string {
+	providerType := strings.ToLower(strings.TrimSpace(s.settingService.GetValue("DATA_PROVIDER_TYPE")))
+	if providerType == "" {
+		providerType = "polygon"
+	}
+
+	switch providerType {
+	case "polygon":
+		return "Polygon.io"
+	default:
+		return strings.Title(providerType)
+	}
+}
+
 // GetRateLimitDelay returns the rate limit delay based on the configured provider
 func (s *Service) GetRateLimitDelay() time.Duration {
 	providerType := strings.ToLower(strings.TrimSpace(s.settingService.GetValue("DATA_PROVIDER_TYPE")))

--- a/internal/providers/service_db_test.go
+++ b/internal/providers/service_db_test.go
@@ -1,11 +1,12 @@
-package test
+package providers
 
 import (
+	"bytes"
 	"context"
-	"os"
+	"log"
+	"path/filepath"
 	"stonks/internal/database"
 	"stonks/internal/models"
-	"stonks/internal/providers"
 	"strings"
 	"testing"
 	"time"
@@ -13,11 +14,7 @@ import (
 
 // setupProvidersTestDB creates a temporary test database for provider tests
 func setupProvidersTestDB(t *testing.T) *database.DB {
-	testDBPath := "./data/providers_test.db"
-
-	if err := os.Remove(testDBPath); err != nil && !os.IsNotExist(err) {
-		t.Logf("Note: Could not delete existing test database: %v", err)
-	}
+	testDBPath := filepath.Join(t.TempDir(), "providers_test.db")
 
 	db, err := database.NewDB(testDBPath)
 	if err != nil {
@@ -26,7 +23,6 @@ func setupProvidersTestDB(t *testing.T) *database.DB {
 
 	t.Cleanup(func() {
 		db.Close()
-		os.Remove(testDBPath)
 	})
 
 	return db
@@ -88,7 +84,7 @@ func TestGetAPIKeyStatus_Polygon(t *testing.T) {
 			}
 
 			symbolService := models.NewSymbolService(db.DB)
-			service := providers.NewService(symbolService, settingService)
+			service := NewService(symbolService, settingService)
 
 			status := service.GetAPIKeyStatus()
 
@@ -116,7 +112,7 @@ func TestGetAPIKeyStatus_UnsupportedProvider(t *testing.T) {
 	}
 
 	symbolService := models.NewSymbolService(db.DB)
-	service := providers.NewService(symbolService, settingService)
+	service := NewService(symbolService, settingService)
 
 	status := service.GetAPIKeyStatus()
 
@@ -141,7 +137,7 @@ func TestUpdateSymbolPrice_MissingAPIKey(t *testing.T) {
 	// Intentionally don't set POLYGON_API_KEY to test missing key scenario
 
 	symbolService := models.NewSymbolService(db.DB)
-	service := providers.NewService(symbolService, settingService)
+	service := NewService(symbolService, settingService)
 
 	err := service.UpdateSymbolPrice(ctx, "AAPL")
 	if err == nil {
@@ -167,7 +163,7 @@ func TestUpdateSymbolPrice_UnsupportedProvider(t *testing.T) {
 	}
 
 	symbolService := models.NewSymbolService(db.DB)
-	service := providers.NewService(symbolService, settingService)
+	service := NewService(symbolService, settingService)
 
 	err := service.UpdateSymbolPrice(ctx, "AAPL")
 	if err == nil {
@@ -202,7 +198,7 @@ func TestUpdateAllSymbolPrices_MissingAPIKey(t *testing.T) {
 		t.Fatalf("failed to create symbol GOOGL: %v", err)
 	}
 
-	service := providers.NewService(symbolService, settingService)
+	service := NewService(symbolService, settingService)
 
 	_, err = service.UpdateAllSymbolPrices(ctx)
 	if err == nil {
@@ -222,7 +218,7 @@ func TestFetchSymbolDetails_MissingAPIKey(t *testing.T) {
 	// No API key - should fail
 
 	symbolService := models.NewSymbolService(db.DB)
-	service := providers.NewService(symbolService, settingService)
+	service := NewService(symbolService, settingService)
 
 	_, err := service.FetchSymbolDetails(ctx, "AAPL")
 	if err == nil {
@@ -246,7 +242,7 @@ func TestFetchDividendHistory_MissingAPIKey(t *testing.T) {
 	// No API key
 
 	symbolService := models.NewSymbolService(db.DB)
-	service := providers.NewService(symbolService, settingService)
+	service := NewService(symbolService, settingService)
 
 	_, err := service.FetchDividendHistory(ctx, "AAPL", 10)
 	if err == nil {
@@ -270,7 +266,7 @@ func TestTestConnection_MissingAPIKey(t *testing.T) {
 	// No API key
 
 	symbolService := models.NewSymbolService(db.DB)
-	service := providers.NewService(symbolService, settingService)
+	service := NewService(symbolService, settingService)
 
 	err := service.TestConnection(ctx)
 	if err == nil {
@@ -314,7 +310,7 @@ func TestGetRateLimitDelay(t *testing.T) {
 			}
 
 			symbolService := models.NewSymbolService(db.DB)
-			service := providers.NewService(symbolService, settingService)
+			service := NewService(symbolService, settingService)
 
 			delay := service.GetRateLimitDelay()
 			if delay != tt.wantDelay {
@@ -324,7 +320,8 @@ func TestGetRateLimitDelay(t *testing.T) {
 	}
 }
 
-// TestDebugLogging tests that debug logging can be controlled
+// TestDebugLogging exercises the provider-selection branch and verifies that
+// debug output masks, rather than exposes, the configured API key.
 func TestDebugLogging(t *testing.T) {
 	db := setupProvidersTestDB(t)
 
@@ -337,19 +334,21 @@ func TestDebugLogging(t *testing.T) {
 	}
 
 	symbolService := models.NewSymbolService(db.DB)
-	// Test with DEBUG_PROVIDERS=1
-	os.Setenv("DEBUG_PROVIDERS", "1")
-	defer os.Unsetenv("DEBUG_PROVIDERS")
-	serviceDebug := providers.NewService(symbolService, settingService)
-	// This test just verifies that the service doesn't panic when DEBUG_PROVIDERS is set
-	// In a real scenario, we'd test actual provider behavior
-	if serviceDebug == nil {
-		t.Fatal("Expected service with debug enabled, got nil")
+	service := NewService(symbolService, settingService)
+	t.Setenv("DEBUG_PROVIDERS", "1")
+
+	var logs bytes.Buffer
+	previousOutput := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(previousOutput) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := service.TestConnection(ctx); err == nil {
+		t.Fatal("Expected cancelled connection test to fail")
 	}
-	// Test without DEBUG_PROVIDERS
-	os.Unsetenv("DEBUG_PROVIDERS")
-	service := providers.NewService(symbolService, settingService)
-	if service == nil {
-		t.Fatal("Expected service with debug disabled, got nil")
+
+	if !strings.Contains(logs.String(), "Using POLYGON provider with API key: tes...345") {
+		t.Fatalf("Expected masked provider debug log, got %q", logs.String())
 	}
 }

--- a/internal/providers/service_db_test.go
+++ b/internal/providers/service_db_test.go
@@ -125,6 +125,23 @@ func TestGetAPIKeyStatus_UnsupportedProvider(t *testing.T) {
 	}
 }
 
+func TestGetAPIKeyStatus_KeylessProvidersAreReadyWithoutAKey(t *testing.T) {
+	for _, providerType := range []string{providerTypeGoogle, providerTypeYFinance} {
+		t.Run(providerType, func(t *testing.T) {
+			db := setupProvidersTestDB(t)
+			settings := models.NewSettingService(db.DB)
+			if err := settings.SetValue("DATA_PROVIDER_TYPE", providerType, ""); err != nil {
+				t.Fatal(err)
+			}
+			service := NewService(models.NewSymbolService(db.DB), settings)
+			status := service.GetAPIKeyStatus()
+			if status.Configured || !status.Ready || status.RequiresAPIKey || status.Masked != "Not required" {
+				t.Fatalf("unexpected keyless status: %+v", status)
+			}
+		})
+	}
+}
+
 // TestUpdateSymbolPrice_MissingAPIKey tests error when API key is missing
 func TestUpdateSymbolPrice_MissingAPIKey(t *testing.T) {
 	ctx := context.Background()
@@ -139,7 +156,7 @@ func TestUpdateSymbolPrice_MissingAPIKey(t *testing.T) {
 	symbolService := models.NewSymbolService(db.DB)
 	service := NewService(symbolService, settingService)
 
-	err := service.UpdateSymbolPrice(ctx, "AAPL")
+	err := service.UpdateSymbolPrice(ctx, "NASDAQ:AAPL")
 	if err == nil {
 		t.Fatal("Expected error when API key is missing, got nil")
 	}
@@ -165,12 +182,12 @@ func TestUpdateSymbolPrice_UnsupportedProvider(t *testing.T) {
 	symbolService := models.NewSymbolService(db.DB)
 	service := NewService(symbolService, settingService)
 
-	err := service.UpdateSymbolPrice(ctx, "AAPL")
+	err := service.UpdateSymbolPrice(ctx, "NASDAQ:AAPL")
 	if err == nil {
 		t.Fatal("Expected error when provider is unsupported, got nil")
 	}
 
-	if !strings.Contains(err.Error(), "failed to get provider") {
+	if !strings.Contains(err.Error(), "unsupported data provider type") {
 		t.Errorf("Expected error about provider, got: %v", err)
 	}
 }
@@ -189,11 +206,11 @@ func TestUpdateAllSymbolPrices_MissingAPIKey(t *testing.T) {
 	symbolService := models.NewSymbolService(db.DB)
 
 	// Create test symbols
-	_, err := symbolService.Create("AAPL")
+	_, err := symbolService.Create("NASDAQ:AAPL")
 	if err != nil {
 		t.Fatalf("failed to create symbol AAPL: %v", err)
 	}
-	_, err = symbolService.Create("GOOGL")
+	_, err = symbolService.Create("NASDAQ:GOOGL")
 	if err != nil {
 		t.Fatalf("failed to create symbol GOOGL: %v", err)
 	}
@@ -220,7 +237,7 @@ func TestFetchSymbolDetails_MissingAPIKey(t *testing.T) {
 	symbolService := models.NewSymbolService(db.DB)
 	service := NewService(symbolService, settingService)
 
-	_, err := service.FetchSymbolDetails(ctx, "AAPL")
+	_, err := service.FetchSymbolDetails(ctx, "NASDAQ:AAPL")
 	if err == nil {
 		t.Fatal("Expected error without API key, got nil")
 	}
@@ -244,7 +261,7 @@ func TestFetchDividendHistory_MissingAPIKey(t *testing.T) {
 	symbolService := models.NewSymbolService(db.DB)
 	service := NewService(symbolService, settingService)
 
-	_, err := service.FetchDividendHistory(ctx, "AAPL", 10)
+	_, err := service.FetchDividendHistory(ctx, "NASDAQ:AAPL", 10)
 	if err == nil {
 		t.Fatal("Expected error without API key, got nil")
 	}

--- a/internal/providers/service_test.go
+++ b/internal/providers/service_test.go
@@ -1,0 +1,22 @@
+package providers
+
+import "testing"
+
+func TestNormalizeProviderType(t *testing.T) {
+	tests := map[string]string{
+		"":               providerTypePolygon,
+		" polygon ":      providerTypePolygon,
+		"google":         providerTypeGoogle,
+		"googlefinance":  providerTypeGoogle,
+		"google_finance": providerTypeGoogle,
+		"yahoo":          providerTypeYFinance,
+		"yahoo_finance":  providerTypeYFinance,
+		"YFINANCE":       providerTypeYFinance,
+		"custom":         "custom",
+	}
+	for input, want := range tests {
+		if got := normalizeProviderType(input); got != want {
+			t.Errorf("normalizeProviderType(%q) = %q, want %q", input, got, want)
+		}
+	}
+}

--- a/internal/providers/service_test.go
+++ b/internal/providers/service_test.go
@@ -49,6 +49,12 @@ func TestBulkPriceUpdateLimitFitsPolygonRequestBudget(t *testing.T) {
 	}
 }
 
+func TestBulkPriceUpdateLimitIsExposed(t *testing.T) {
+	if got := BulkPriceUpdateLimit(); got != bulkPriceUpdateLimit {
+		t.Fatalf("BulkPriceUpdateLimit() = %d, want %d", got, bulkPriceUpdateLimit)
+	}
+}
+
 func TestConvertDividendsToInfoSkipsNilEntries(t *testing.T) {
 	dividends := convertDividendsToInfo([]*Dividend{nil, {Symbol: "AAPL", CashAmount: 0.25}})
 	if len(dividends) != 1 || dividends[0].Symbol != "AAPL" {

--- a/internal/providers/service_test.go
+++ b/internal/providers/service_test.go
@@ -20,3 +20,38 @@ func TestNormalizeProviderType(t *testing.T) {
 		}
 	}
 }
+
+func TestCanonicalProviderTypeRejectsUnsupportedValues(t *testing.T) {
+	if _, ok := CanonicalProviderType("unsupported"); ok {
+		t.Fatal("unsupported provider type was accepted")
+	}
+}
+
+func TestProviderProfiles(t *testing.T) {
+	profiles := ProviderProfiles()
+	if len(profiles) != 3 {
+		t.Fatalf("expected three provider profiles, got %d", len(profiles))
+	}
+	if profiles[0].ID != providerTypePolygon || !profiles[0].RequiresAPIKey || !profiles[0].SupportsDividends {
+		t.Fatalf("unexpected Polygon profile: %+v", profiles[0])
+	}
+	if profiles[1].ID != providerTypeGoogle || profiles[1].SupportsDividends {
+		t.Fatalf("unexpected Google Finance profile: %+v", profiles[1])
+	}
+	if profiles[2].ID != providerTypeYFinance || profiles[2].RequiresAPIKey || !profiles[2].SupportsDividends {
+		t.Fatalf("unexpected Yahoo Finance profile: %+v", profiles[2])
+	}
+}
+
+func TestBulkPriceUpdateLimitFitsPolygonRequestBudget(t *testing.T) {
+	if bulkPriceUpdateLimit >= 25 {
+		t.Fatalf("bulk price update limit %d can exceed the five-minute Polygon request budget", bulkPriceUpdateLimit)
+	}
+}
+
+func TestConvertDividendsToInfoSkipsNilEntries(t *testing.T) {
+	dividends := convertDividendsToInfo([]*Dividend{nil, {Symbol: "AAPL", CashAmount: 0.25}})
+	if len(dividends) != 1 || dividends[0].Symbol != "AAPL" {
+		t.Fatalf("unexpected converted dividends: %+v", dividends)
+	}
+}

--- a/internal/providers/yfinance.go
+++ b/internal/providers/yfinance.go
@@ -1,0 +1,295 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+// YFinanceProvider retrieves Yahoo Finance data directly over HTTP. The name
+// is retained for compatibility with the yfinance ecosystem, but this Go
+// implementation does not require Python or the yfinance package.
+type YFinanceProvider struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+type yahooChartResponse struct {
+	Chart struct {
+		Result []struct {
+			Meta       yahooMeta            `json:"meta"`
+			Timestamp  []int64              `json:"timestamp"`
+			Indicators yahooChartIndicators `json:"indicators"`
+			Events     yahooChartEvents     `json:"events"`
+		} `json:"result"`
+		Error *struct {
+			Code        string `json:"code"`
+			Description string `json:"description"`
+		} `json:"error"`
+	} `json:"chart"`
+}
+
+type yahooMeta struct {
+	Currency             string  `json:"currency"`
+	Symbol               string  `json:"symbol"`
+	ExchangeName         string  `json:"exchangeName"`
+	FullExchangeName     string  `json:"fullExchangeName"`
+	InstrumentType       string  `json:"instrumentType"`
+	RegularMarketTime    int64   `json:"regularMarketTime"`
+	RegularMarketPrice   float64 `json:"regularMarketPrice"`
+	RegularMarketDayHigh float64 `json:"regularMarketDayHigh"`
+	RegularMarketDayLow  float64 `json:"regularMarketDayLow"`
+	RegularMarketVolume  float64 `json:"regularMarketVolume"`
+	ChartPreviousClose   float64 `json:"chartPreviousClose"`
+}
+
+type yahooChartIndicators struct {
+	Quote []struct {
+		Open   []*float64 `json:"open"`
+		High   []*float64 `json:"high"`
+		Low    []*float64 `json:"low"`
+		Close  []*float64 `json:"close"`
+		Volume []*float64 `json:"volume"`
+	} `json:"quote"`
+}
+
+type yahooChartEvents struct {
+	Dividends map[string]struct {
+		Amount float64 `json:"amount"`
+	} `json:"dividends"`
+}
+
+// NewYFinanceProvider creates a direct Yahoo Finance HTTP provider. The
+// YFINANCE_BASE_URL environment variable is useful for testing or proxies.
+func NewYFinanceProvider() *YFinanceProvider {
+	baseURL := os.Getenv("YFINANCE_BASE_URL")
+	if baseURL == "" {
+		baseURL = "https://query1.finance.yahoo.com"
+	}
+	return &YFinanceProvider{
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+func newYFinanceProviderForTest(client *http.Client, baseURL string) *YFinanceProvider {
+	provider := NewYFinanceProvider()
+	provider.httpClient = client
+	provider.baseURL = strings.TrimRight(baseURL, "/")
+	return provider
+}
+
+func (p *YFinanceProvider) GetQuote(ctx context.Context, symbol string) (*Quote, error) {
+	result, err := p.fetchChart(ctx, symbol, "5d")
+	if err != nil {
+		return nil, fmt.Errorf("yfinance: %w", err)
+	}
+	meta := result.Meta
+	latest := latestYahooQuote(result)
+	price := meta.RegularMarketPrice
+	if price <= 0 {
+		price = latest.close
+	}
+	if price <= 0 {
+		return nil, errors.New("yfinance: quote returned no positive price")
+	}
+	previousClose := meta.ChartPreviousClose
+	if previousClose <= 0 {
+		previousClose = latest.previousClose
+	}
+	timestamp := time.Unix(meta.RegularMarketTime, 0)
+	if meta.RegularMarketTime == 0 {
+		timestamp = time.Now()
+	}
+	return &Quote{
+		Symbol:        meta.Symbol,
+		Price:         price,
+		Open:          latest.open,
+		High:          firstPositive(meta.RegularMarketDayHigh, latest.high),
+		Low:           firstPositive(meta.RegularMarketDayLow, latest.low),
+		Volume:        firstPositive(meta.RegularMarketVolume, latest.volume),
+		PreviousClose: previousClose,
+		Timestamp:     timestamp,
+	}, nil
+}
+
+func (p *YFinanceProvider) GetTickerDetails(ctx context.Context, symbol string) (*TickerDetails, error) {
+	result, err := p.fetchChart(ctx, symbol, "5d")
+	if err != nil {
+		return nil, fmt.Errorf("yfinance: %w", err)
+	}
+	meta := result.Meta
+	return &TickerDetails{
+		Symbol:   meta.Symbol,
+		Name:     meta.Symbol,
+		Market:   firstNonEmpty(meta.FullExchangeName, meta.ExchangeName),
+		Type:     meta.InstrumentType,
+		Active:   true,
+		Currency: meta.Currency,
+	}, nil
+}
+
+func (p *YFinanceProvider) GetDividends(ctx context.Context, symbol string, limit int) ([]*Dividend, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+	result, err := p.fetchChart(ctx, symbol, "10y")
+	if err != nil {
+		return nil, fmt.Errorf("yfinance: %w", err)
+	}
+	items := make([]*Dividend, 0, len(result.Events.Dividends))
+	for epoch, event := range result.Events.Dividends {
+		seconds, parseErr := parseInt64(epoch)
+		if parseErr != nil {
+			continue
+		}
+		items = append(items, &Dividend{
+			Symbol:         result.Meta.Symbol,
+			CashAmount:     event.Amount,
+			ExDividendDate: time.Unix(seconds, 0).UTC().Format("2006-01-02"),
+			DividendType:   "cash",
+		})
+	}
+	sortDividendsNewestFirst(items)
+	if len(items) > limit {
+		items = items[:limit]
+	}
+	return items, nil
+}
+
+func (p *YFinanceProvider) ValidateConnection(ctx context.Context) error {
+	_, err := p.GetQuote(ctx, "AAPL")
+	return err
+}
+
+func (p *YFinanceProvider) Name() string { return "Yahoo Finance (yfinance)" }
+
+type yahooChartResult struct {
+	Meta       yahooMeta
+	Timestamp  []int64
+	Indicators yahooChartIndicators
+	Events     yahooChartEvents
+}
+
+func (p *YFinanceProvider) fetchChart(ctx context.Context, symbol, rangeValue string) (*yahooChartResult, error) {
+	symbol = strings.ToUpper(strings.TrimSpace(symbol))
+	if symbol == "" {
+		return nil, errors.New("symbol is required")
+	}
+	query := url.Values{}
+	query.Set("range", rangeValue)
+	query.Set("interval", "1d")
+	query.Set("events", "div,splits")
+	endpoint := fmt.Sprintf("%s/v8/finance/chart/%s?%s", p.baseURL, url.PathEscape(symbol), query.Encode())
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("User-Agent", "Wheeler/1.0 (+https://github.com/phbrgnomo/wheeler)")
+	response, err := p.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("execute request: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Yahoo Finance returned HTTP %d", response.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, 8<<20))
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	var payload yahooChartResponse
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	if payload.Chart.Error != nil {
+		return nil, fmt.Errorf("Yahoo Finance error %s: %s", payload.Chart.Error.Code, payload.Chart.Error.Description)
+	}
+	if len(payload.Chart.Result) == 0 {
+		return nil, errors.New("Yahoo Finance returned no chart result")
+	}
+	result := payload.Chart.Result[0]
+	return &yahooChartResult{
+		Meta: result.Meta, Timestamp: result.Timestamp,
+		Indicators: result.Indicators, Events: result.Events,
+	}, nil
+}
+
+type yahooLatestQuote struct {
+	open, high, low, close, volume, previousClose float64
+}
+
+func latestYahooQuote(result *yahooChartResult) yahooLatestQuote {
+	if len(result.Indicators.Quote) == 0 {
+		return yahooLatestQuote{}
+	}
+	quote := result.Indicators.Quote[0]
+	latest := -1
+	for i := len(quote.Close) - 1; i >= 0; i-- {
+		if quote.Close[i] != nil {
+			latest = i
+			break
+		}
+	}
+	if latest < 0 {
+		return yahooLatestQuote{}
+	}
+	previous := -1
+	for i := latest - 1; i >= 0; i-- {
+		if quote.Close[i] != nil {
+			previous = i
+			break
+		}
+	}
+	get := func(values []*float64, index int) float64 {
+		if index >= 0 && index < len(values) && values[index] != nil {
+			return *values[index]
+		}
+		return 0
+	}
+	return yahooLatestQuote{
+		open: get(quote.Open, latest), high: get(quote.High, latest),
+		low: get(quote.Low, latest), close: get(quote.Close, latest),
+		volume: get(quote.Volume, latest), previousClose: get(quote.Close, previous),
+	}
+}
+
+func firstPositive(primary, fallback float64) float64 {
+	if primary > 0 {
+		return primary
+	}
+	return fallback
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func parseInt64(value string) (int64, error) {
+	var result int64
+	_, err := fmt.Sscan(value, &result)
+	return result, err
+}
+
+func sortDividendsNewestFirst(items []*Dividend) {
+	for i := 1; i < len(items); i++ {
+		for j := i; j > 0 && items[j].ExDividendDate > items[j-1].ExDividendDate; j-- {
+			items[j], items[j-1] = items[j-1], items[j]
+		}
+	}
+}
+
+var _ Provider = (*YFinanceProvider)(nil)

--- a/internal/providers/yfinance.go
+++ b/internal/providers/yfinance.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -279,17 +281,13 @@ func firstNonEmpty(values ...string) string {
 }
 
 func parseInt64(value string) (int64, error) {
-	var result int64
-	_, err := fmt.Sscan(value, &result)
-	return result, err
+	return strconv.ParseInt(strings.TrimSpace(value), 10, 64)
 }
 
 func sortDividendsNewestFirst(items []*Dividend) {
-	for i := 1; i < len(items); i++ {
-		for j := i; j > 0 && items[j].ExDividendDate > items[j-1].ExDividendDate; j-- {
-			items[j], items[j-1] = items[j-1], items[j]
-		}
-	}
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].ExDividendDate > items[j].ExDividendDate
+	})
 }
 
 var _ Provider = (*YFinanceProvider)(nil)

--- a/internal/providers/yfinance_test.go
+++ b/internal/providers/yfinance_test.go
@@ -45,6 +45,12 @@ func TestYFinanceProviderQuoteAndDetails(t *testing.T) {
 	}
 }
 
+func TestParseInt64RejectsTrailingCharacters(t *testing.T) {
+	if _, err := parseInt64("1723507200invalid"); err == nil {
+		t.Fatal("expected invalid epoch to be rejected")
+	}
+}
+
 func TestYFinanceProviderDividendsNewestFirstAndLimited(t *testing.T) {
 	provider := newYFinanceProviderForTest(&http.Client{Transport: yahooRoundTripper{body: yahooChartFixture}}, "http://yahoo.test")
 	dividends, err := provider.GetDividends(context.Background(), "AAPL", 1)

--- a/internal/providers/yfinance_test.go
+++ b/internal/providers/yfinance_test.go
@@ -1,0 +1,87 @@
+package providers
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+const yahooChartFixture = `{"chart":{"result":[{"meta":{"currency":"USD","symbol":"AAPL","exchangeName":"NMS","fullExchangeName":"NasdaqGS","instrumentType":"EQUITY","regularMarketTime":1724328000,"regularMarketPrice":189.42,"regularMarketDayHigh":190.00,"regularMarketDayLow":187.00,"regularMarketVolume":123456,"chartPreviousClose":188.50},"timestamp":[1724241600,1724328000],"indicators":{"quote":[{"open":[187.0,188.0],"high":[189.0,190.0],"low":[186.0,187.0],"close":[188.5,189.42],"volume":[100,123456]}]},"events":{"dividends":{"1723507200":{"amount":0.25},"1715731200":{"amount":0.24}}}}],"error":null}}`
+
+type yahooRoundTripper struct{ body string }
+
+func (t yahooRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	if request.URL.Path != "/v8/finance/chart/AAPL" {
+		return nil, fmt.Errorf("unexpected path: %s", request.URL.Path)
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(t.body)),
+		Header:     make(http.Header),
+		Request:    request,
+	}, nil
+}
+
+func TestYFinanceProviderQuoteAndDetails(t *testing.T) {
+	provider := newYFinanceProviderForTest(&http.Client{Transport: yahooRoundTripper{body: yahooChartFixture}}, "http://yahoo.test")
+
+	quote, err := provider.GetQuote(context.Background(), "AAPL")
+	if err != nil {
+		t.Fatalf("GetQuote failed: %v", err)
+	}
+	if quote.Symbol != "AAPL" || quote.Price != 189.42 || quote.PreviousClose != 188.50 {
+		t.Fatalf("unexpected quote: %+v", quote)
+	}
+
+	details, err := provider.GetTickerDetails(context.Background(), "AAPL")
+	if err != nil {
+		t.Fatalf("GetTickerDetails failed: %v", err)
+	}
+	if details.Symbol != "AAPL" || details.Market != "NasdaqGS" || details.Currency != "USD" {
+		t.Fatalf("unexpected details: %+v", details)
+	}
+}
+
+func TestYFinanceProviderDividendsNewestFirstAndLimited(t *testing.T) {
+	provider := newYFinanceProviderForTest(&http.Client{Transport: yahooRoundTripper{body: yahooChartFixture}}, "http://yahoo.test")
+	dividends, err := provider.GetDividends(context.Background(), "AAPL", 1)
+	if err != nil {
+		t.Fatalf("GetDividends failed: %v", err)
+	}
+	if len(dividends) != 1 || dividends[0].CashAmount != 0.25 || dividends[0].ExDividendDate != "2024-08-13" {
+		t.Fatalf("unexpected dividends: %+v", dividends)
+	}
+}
+
+func TestYFinanceProviderUsesMostRecentNonNullClose(t *testing.T) {
+	fixture := strings.Replace(yahooChartFixture, `"regularMarketPrice":189.42`, `"regularMarketPrice":0`, 1)
+	fixture = strings.Replace(fixture, `"close":[188.5,189.42]`, `"close":[188.5,189.42,null]`, 1)
+	provider := newYFinanceProviderForTest(&http.Client{Transport: yahooRoundTripper{body: fixture}}, "http://yahoo.test")
+
+	quote, err := provider.GetQuote(context.Background(), "AAPL")
+	if err != nil {
+		t.Fatalf("GetQuote failed: %v", err)
+	}
+	if quote.Price != 189.42 || quote.PreviousClose != 188.5 {
+		t.Fatalf("unexpected quote after trailing null close: %+v", quote)
+	}
+}
+
+func TestYFinanceProviderHTTPError(t *testing.T) {
+	client := &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusTooManyRequests, Body: io.NopCloser(strings.NewReader(""))}, nil
+	})}
+	provider := newYFinanceProviderForTest(client, "http://yahoo.test")
+	if _, err := provider.GetQuote(context.Background(), "AAPL"); err == nil || !strings.Contains(err.Error(), "HTTP 429") {
+		t.Fatalf("expected HTTP 429 error, got %v", err)
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}

--- a/internal/web/import_handlers.go
+++ b/internal/web/import_handlers.go
@@ -1011,9 +1011,9 @@ func (s *Server) processTreasuryRecord(csvRecord CSVTreasuryRecord, rowNum int) 
 	existingTreasury, err := s.treasuryService.GetByCUSPID(csvRecord.CUSPID)
 	if err == nil && existingTreasury != nil {
 		// Treasury already exists, check if it's the same one
-		if existingTreasury.Purchased.Equal(purchasedDate) && 
-		   existingTreasury.Maturity.Equal(maturityDate) && 
-		   existingTreasury.Amount == amount {
+		if existingTreasury.Purchased.Equal(purchasedDate) &&
+			existingTreasury.Maturity.Equal(maturityDate) &&
+			existingTreasury.Amount == amount {
 			return existingTreasury, false, nil // Already exists, skip
 		}
 	}
@@ -1145,7 +1145,7 @@ func (s *Server) handleCreateBackup(w http.ResponseWriter, r *http.Request) {
 
 	// Construct full path to database file in data directory
 	sourceFilePath := filepath.Join("./data", dbFileName)
-	
+
 	// Check if source file exists
 	if _, err := os.Stat(sourceFilePath); os.IsNotExist(err) {
 		log.Printf("[BACKUP] Source file does not exist: %s", sourceFilePath)
@@ -1323,19 +1323,6 @@ func (s *Server) handleSetCurrentDatabase(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Close existing database connection
-	log.Printf("[SET_DATABASE] Closing existing database connection")
-	if err := s.db.Close(); err != nil {
-		log.Printf("[SET_DATABASE] Warning: Error closing existing database: %v", err)
-	}
-
-	// Set the current database in the filesystem
-	if err := database.SetCurrentDatabase(dbName); err != nil {
-		log.Printf("[SET_DATABASE] Error setting current database: %v", err)
-		http.Error(w, `{"success": false, "error": "Failed to set current database"}`, http.StatusInternalServerError)
-		return
-	}
-
 	// Connect to the new database
 	log.Printf("[SET_DATABASE] Connecting to new database: %s", dbPath)
 	dbWrapper, err := database.NewDB(dbPath)
@@ -1344,17 +1331,20 @@ func (s *Server) handleSetCurrentDatabase(w http.ResponseWriter, r *http.Request
 		http.Error(w, `{"success": false, "error": "Failed to connect to new database"}`, http.StatusInternalServerError)
 		return
 	}
+	// Set the current database in the filesystem only after a connection to it
+	// has been established, so a failed switch leaves the active service set intact.
+	if err := database.SetCurrentDatabase(dbName); err != nil {
+		log.Printf("[SET_DATABASE] Error setting current database: %v", err)
+		dbWrapper.DB.Close()
+		http.Error(w, `{"success": false, "error": "Failed to set current database"}`, http.StatusInternalServerError)
+		return
+	}
 
-	// Update server's database connection and reinitialize all services
+	// Update server's database connection and reinitialize all services.
 	log.Printf("[SET_DATABASE] Reinitializing services with new database connection")
-	s.db = dbWrapper.DB
-	s.optionService = models.NewOptionService(dbWrapper.DB)
-	s.symbolService = models.NewSymbolService(dbWrapper.DB)
-	s.treasuryService = models.NewTreasuryService(dbWrapper.DB)
-	s.longPositionService = models.NewLongPositionService(dbWrapper.DB)
-	s.dividendService = models.NewDividendService(dbWrapper.DB)
-	s.settingService = models.NewSettingService(dbWrapper.DB)
-	s.metricService = models.NewMetricService(dbWrapper.DB)
+	if err := s.switchServices(dbWrapper.DB); err != nil {
+		log.Printf("[SET_DATABASE] Warning: Error closing previous database: %v", err)
+	}
 
 	log.Printf("[SET_DATABASE] Successfully switched to database: %s", dbName)
 
@@ -1619,15 +1609,15 @@ func (s *Server) parseSQLStatements(sqlContent string) []string {
 	lines := strings.Split(sqlContent, "\n")
 	var statements []string
 	var currentStatement strings.Builder
-	
+
 	for _, line := range lines {
 		trimmedLine := strings.TrimSpace(line)
-		
+
 		// Skip empty lines and comment lines
 		if trimmedLine == "" || strings.HasPrefix(trimmedLine, "--") {
 			continue
 		}
-		
+
 		// Remove inline comments (everything after -- on the same line)
 		if commentPos := strings.Index(trimmedLine, "--"); commentPos != -1 {
 			trimmedLine = strings.TrimSpace(trimmedLine[:commentPos])
@@ -1635,13 +1625,13 @@ func (s *Server) parseSQLStatements(sqlContent string) []string {
 				continue // Skip if line becomes empty after removing comment
 			}
 		}
-		
+
 		// Add line to current statement
 		if currentStatement.Len() > 0 {
 			currentStatement.WriteString(" ")
 		}
 		currentStatement.WriteString(trimmedLine)
-		
+
 		// If line ends with semicolon, we have a complete statement
 		if strings.HasSuffix(trimmedLine, ";") {
 			statement := strings.TrimSpace(currentStatement.String())
@@ -1654,7 +1644,7 @@ func (s *Server) parseSQLStatements(sqlContent string) []string {
 			currentStatement.Reset()
 		}
 	}
-	
+
 	// Handle any remaining statement that doesn't end with semicolon
 	if currentStatement.Len() > 0 {
 		statement := strings.TrimSpace(currentStatement.String())
@@ -1662,6 +1652,6 @@ func (s *Server) parseSQLStatements(sqlContent string) []string {
 			statements = append(statements, statement)
 		}
 	}
-	
+
 	return statements
 }

--- a/internal/web/market_handlers.go
+++ b/internal/web/market_handlers.go
@@ -1,0 +1,16 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"stonks/internal/markets"
+)
+
+func (s *Server) marketsAPIHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(markets.Definitions())
+}

--- a/internal/web/polygon_handlers.go
+++ b/internal/web/polygon_handlers.go
@@ -23,7 +23,7 @@ func (s *Server) polygonTestHandler(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 
 	// Test the connection
-	err := s.polygonService.TestConnection(ctx)
+	err := s.providerService.TestConnection(ctx)
 	
 	response := map[string]interface{}{
 		"success": err == nil,
@@ -81,7 +81,7 @@ func (s *Server) polygonUpdatePricesHandler(w http.ResponseWriter, r *http.Reque
 		log.Printf("[POLYGON API] Updating prices for %d symbols (prioritized order)", len(symbols))
 
 		for _, symbol := range symbols {
-			if err := s.polygonService.UpdateSymbolPrice(ctx, symbol); err != nil {
+			if err := s.providerService.UpdateSymbolPrice(ctx, symbol); err != nil {
 				log.Printf("[POLYGON API] Failed to update %s: %v", symbol, err)
 				errors = append(errors, symbol+": "+err.Error())
 				failed++
@@ -97,7 +97,7 @@ func (s *Server) polygonUpdatePricesHandler(w http.ResponseWriter, r *http.Reque
 		log.Printf("[POLYGON API] Updating prices for specific symbols: %v", request.Symbols)
 
 		for _, symbol := range request.Symbols {
-			if err := s.polygonService.UpdateSymbolPrice(ctx, symbol); err != nil {
+			if err := s.providerService.UpdateSymbolPrice(ctx, symbol); err != nil {
 				log.Printf("[POLYGON API] Failed to update %s: %v", symbol, err)
 				errors = append(errors, symbol+": "+err.Error())
 				failed++
@@ -157,7 +157,7 @@ func (s *Server) polygonSymbolInfoHandler(w http.ResponseWriter, r *http.Request
 	defer cancel()
 
 	// Get symbol info from Polygon
-	info, err := s.polygonService.FetchSymbolDetails(ctx, symbol)
+	info, err := s.providerService.FetchSymbolDetails(ctx, symbol)
 	if err != nil {
 		log.Printf("[POLYGON API] Error getting symbol info for %s: %v", symbol, err)
 		response := map[string]interface{}{
@@ -171,7 +171,7 @@ func (s *Server) polygonSymbolInfoHandler(w http.ResponseWriter, r *http.Request
 	}
 
 	// Get dividend history (optional)
-	dividends, err := s.polygonService.FetchDividendHistory(ctx, symbol, 5)
+	dividends, err := s.providerService.FetchDividendHistory(ctx, symbol, 5)
 	if err != nil {
 		log.Printf("[POLYGON API] Warning: failed to get dividend history for %s: %v", symbol, err)
 		// Continue without dividends
@@ -201,14 +201,14 @@ func (s *Server) polygonStatusHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	status := s.polygonService.GetAPIKeyStatus()
+	status := s.providerService.GetAPIKeyStatus()
 
 	// Test connection if API key is configured
 	if status.Configured {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
-		if err := s.polygonService.TestConnection(ctx); err != nil {
+		if err := s.providerService.TestConnection(ctx); err != nil {
 			status.Valid = false
 			status.Error = err.Error()
 		} else {
@@ -266,7 +266,7 @@ func (s *Server) polygonFetchDividendsHandler(w http.ResponseWriter, r *http.Req
 		log.Printf("[POLYGON API] Fetching dividends for %d symbols (prioritized order)", len(symbols))
 
 		for _, symbol := range symbols {
-			dividends, err := s.polygonService.FetchDividendHistory(ctx, symbol, request.Limit)
+			dividends, err := s.providerService.FetchDividendHistory(ctx, symbol, request.Limit)
 			processed++
 			
 			if err != nil {
@@ -288,7 +288,7 @@ func (s *Server) polygonFetchDividendsHandler(w http.ResponseWriter, r *http.Req
 		log.Printf("[POLYGON API] Fetching dividends for specific symbols: %v", request.Symbols)
 
 		for _, symbol := range request.Symbols {
-			dividends, err := s.polygonService.FetchDividendHistory(ctx, symbol, request.Limit)
+			dividends, err := s.providerService.FetchDividendHistory(ctx, symbol, request.Limit)
 			processed++
 			
 			if err != nil {

--- a/internal/web/polygon_handlers.go
+++ b/internal/web/polygon_handlers.go
@@ -91,8 +91,8 @@ func (s *Server) polygonUpdatePricesHandler(w http.ResponseWriter, r *http.Reque
 				updated++
 			}
 
-			// Rate limiting for free tier (5 requests per minute)
-			time.Sleep(12 * time.Second)
+			// Rate limiting based on provider configuration
+			time.Sleep(s.providerService.GetRateLimitDelay())
 		}
 	} else {
 		// Update specific symbols
@@ -107,9 +107,9 @@ func (s *Server) polygonUpdatePricesHandler(w http.ResponseWriter, r *http.Reque
 				updated++
 			}
 
-			// Rate limiting
+			// Rate limiting based on provider configuration
 			if len(request.Symbols) > 1 {
-				time.Sleep(12 * time.Second)
+				time.Sleep(s.providerService.GetRateLimitDelay())
 			}
 		}
 	}
@@ -158,7 +158,7 @@ func (s *Server) polygonSymbolInfoHandler(w http.ResponseWriter, r *http.Request
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Get symbol info from Polygon
+	// Get symbol info from configured data provider
 	info, err := s.providerService.FetchSymbolDetails(ctx, symbol)
 	if err != nil {
 		log.Printf("[POLYGON API] Error getting symbol info for %s: %v", symbol, err)
@@ -282,8 +282,8 @@ func (s *Server) polygonFetchDividendsHandler(w http.ResponseWriter, r *http.Req
 				})
 			}
 
-			// Rate limiting for free tier (5 requests per minute)
-			time.Sleep(12 * time.Second)
+			// Rate limiting based on provider configuration
+			time.Sleep(s.providerService.GetRateLimitDelay())
 		}
 	} else {
 		// Fetch dividends for specific symbols
@@ -304,9 +304,9 @@ func (s *Server) polygonFetchDividendsHandler(w http.ResponseWriter, r *http.Req
 				})
 			}
 
-			// Rate limiting
+			// Rate limiting based on provider configuration
 			if len(request.Symbols) > 1 {
-				time.Sleep(12 * time.Second)
+				time.Sleep(s.providerService.GetRateLimitDelay())
 			}
 		}
 	}

--- a/internal/web/polygon_handlers.go
+++ b/internal/web/polygon_handlers.go
@@ -20,11 +20,52 @@ func (s *Server) polygonTestHandler(w http.ResponseWriter, r *http.Request) {
 	log.Printf("[POLYGON API] Testing API connection")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	package web
 
-	// Test the connection
-	err := s.providerService.TestConnection(ctx)
-	
+	import (
+		"context"
+		"encoding/json"
+		"fmt"
+		"log"
+		"net/http"
+		"strings"
+		"time"
+	)
+
+	// polygonTestHandler tests the data provider API connection
+	func (s *Server) polygonTestHandler(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		providerName := s.providerService.Name()
+		logPrefix := fmt.Sprintf("[%s API]", strings.ToUpper(providerName))
+		log.Printf("%s Testing API connection", logPrefix)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		err := s.providerService.TestConnection(ctx)
+		
+		response := map[string]interface{}{
+			"success":  err == nil,
+			"provider": providerName,
+		}
+
+		if err != nil {
+			response["error"] = err.Error()
+			log.Printf("%s Connection test failed: %v", logPrefix, err)
+		} else {
+			response["message"] = "API key is valid and connection successful"
+			log.Printf("%s Connection test successful", logPrefix)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			log.Printf("%s Error encoding test response: %v", logPrefix, err)
+		}
+	}
 	response := map[string]interface{}{
 		"success": err == nil,
 	}

--- a/internal/web/polygon_handlers.go
+++ b/internal/web/polygon_handlers.go
@@ -10,77 +10,38 @@ import (
 	"time"
 )
 
-// polygonTestHandler tests the Polygon API connection
+// polygonTestHandler tests the data provider API connection
 func (s *Server) polygonTestHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
-	log.Printf("[POLYGON API] Testing API connection")
+	providerName := s.providerService.Name()
+	logPrefix := fmt.Sprintf("[%s API]", strings.ToUpper(providerName))
+	log.Printf("%s Testing API connection", logPrefix)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	package web
+	defer cancel()
 
-	import (
-		"context"
-		"encoding/json"
-		"fmt"
-		"log"
-		"net/http"
-		"strings"
-		"time"
-	)
+	err := s.providerService.TestConnection(ctx)
 
-	// polygonTestHandler tests the data provider API connection
-	func (s *Server) polygonTestHandler(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-
-		providerName := s.providerService.Name()
-		logPrefix := fmt.Sprintf("[%s API]", strings.ToUpper(providerName))
-		log.Printf("%s Testing API connection", logPrefix)
-
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-
-		err := s.providerService.TestConnection(ctx)
-		
-		response := map[string]interface{}{
-			"success":  err == nil,
-			"provider": providerName,
-		}
-
-		if err != nil {
-			response["error"] = err.Error()
-			log.Printf("%s Connection test failed: %v", logPrefix, err)
-		} else {
-			response["message"] = "API key is valid and connection successful"
-			log.Printf("%s Connection test successful", logPrefix)
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(response); err != nil {
-			log.Printf("%s Error encoding test response: %v", logPrefix, err)
-		}
-	}
 	response := map[string]interface{}{
-		"success": err == nil,
+		"success":  err == nil,
+		"provider": providerName,
 	}
 
 	if err != nil {
 		response["error"] = err.Error()
-		log.Printf("[POLYGON API] Connection test failed: %v", err)
+		log.Printf("%s Connection test failed: %v", logPrefix, err)
 	} else {
 		response["message"] = "API key is valid and connection successful"
-		log.Printf("[POLYGON API] Connection test successful")
+		log.Printf("%s Connection test successful", logPrefix)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(response); err != nil {
-		log.Printf("[POLYGON API] Error encoding test response: %v", err)
+		log.Printf("%s Error encoding test response: %v", logPrefix, err)
 	}
 }
 
@@ -235,7 +196,7 @@ func (s *Server) polygonSymbolInfoHandler(w http.ResponseWriter, r *http.Request
 	}
 }
 
-// polygonStatusHandler returns the status of the Polygon integration  
+// polygonStatusHandler returns the status of the Polygon integration
 func (s *Server) polygonStatusHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -309,7 +270,7 @@ func (s *Server) polygonFetchDividendsHandler(w http.ResponseWriter, r *http.Req
 		for _, symbol := range symbols {
 			dividends, err := s.providerService.FetchDividendHistory(ctx, symbol, request.Limit)
 			processed++
-			
+
 			if err != nil {
 				log.Printf("[POLYGON API] Failed to fetch dividends for %s: %v", symbol, err)
 				errors = append(errors, symbol+": "+err.Error())
@@ -331,7 +292,7 @@ func (s *Server) polygonFetchDividendsHandler(w http.ResponseWriter, r *http.Req
 		for _, symbol := range request.Symbols {
 			dividends, err := s.providerService.FetchDividendHistory(ctx, symbol, request.Limit)
 			processed++
-			
+
 			if err != nil {
 				log.Printf("[POLYGON API] Failed to fetch dividends for %s: %v", symbol, err)
 				errors = append(errors, symbol+": "+err.Error())
@@ -366,7 +327,7 @@ func (s *Server) polygonFetchDividendsHandler(w http.ResponseWriter, r *http.Req
 			totalDividends += count
 		}
 	}
-	
+
 	response["message"] = fmt.Sprintf("Dividend fetch completed: %d symbols processed, %d total dividends found", processed, totalDividends)
 
 	log.Printf("[POLYGON API] Dividend fetch completed: %d symbols processed, %d total dividends found", processed, totalDividends)

--- a/internal/web/polygon_handlers.go
+++ b/internal/web/polygon_handlers.go
@@ -8,17 +8,27 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"stonks/internal/providers"
 )
 
-// polygonTestHandler tests the data provider API connection
-func (s *Server) polygonTestHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) providerLogPrefix() string {
+	name := strings.ToUpper(strings.TrimSpace(s.providerService.Name()))
+	if name == "" {
+		name = "PROVIDER"
+	}
+	return fmt.Sprintf("[%s API]", name)
+}
+
+// providerTestHandler tests the data provider API connection
+func (s *Server) providerTestHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
 	providerName := s.providerService.Name()
-	logPrefix := fmt.Sprintf("[%s API]", strings.ToUpper(providerName))
+	logPrefix := s.providerLogPrefix()
 	log.Printf("%s Testing API connection", logPrefix)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -45,14 +55,15 @@ func (s *Server) polygonTestHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// polygonUpdatePricesHandler triggers price updates for symbols
-func (s *Server) polygonUpdatePricesHandler(w http.ResponseWriter, r *http.Request) {
+// providerUpdatePricesHandler triggers price updates for symbols
+func (s *Server) providerUpdatePricesHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
-	log.Printf("[POLYGON API] Starting price update request")
+	logPrefix := s.providerLogPrefix()
+	log.Printf("%s Starting price update request", logPrefix)
 
 	// Parse request body to get specific symbols (optional)
 	var request struct {
@@ -68,92 +79,66 @@ func (s *Server) polygonUpdatePricesHandler(w http.ResponseWriter, r *http.Reque
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	var updated, failed int
-	var errors []string
+	var (
+		result *providers.BulkPriceUpdateResult
+		err    error
+	)
 
 	if request.All || len(request.Symbols) == 0 {
-		// Update all symbols (prioritized: active positions first)
-		symbols, err := s.symbolService.GetPrioritizedSymbols()
-		if err != nil {
-			log.Printf("[POLYGON API] Error getting prioritized symbols: %v", err)
-			http.Error(w, "Failed to get symbols", http.StatusInternalServerError)
-			return
-		}
-
-		log.Printf("[POLYGON API] Updating prices for %d symbols (prioritized order)", len(symbols))
-
-		for _, symbol := range symbols {
-			if err := s.providerService.UpdateSymbolPrice(ctx, symbol); err != nil {
-				log.Printf("[POLYGON API] Failed to update %s: %v", symbol, err)
-				errors = append(errors, symbol+": "+err.Error())
-				failed++
-			} else {
-				updated++
-			}
-
-			// Rate limiting based on provider configuration
-			time.Sleep(s.providerService.GetRateLimitDelay())
-		}
+		result, err = s.providerService.UpdateAllSymbolPrices(ctx)
 	} else {
-		// Update specific symbols
-		log.Printf("[POLYGON API] Updating prices for specific symbols: %v", request.Symbols)
-
-		for _, symbol := range request.Symbols {
-			if err := s.providerService.UpdateSymbolPrice(ctx, symbol); err != nil {
-				log.Printf("[POLYGON API] Failed to update %s: %v", symbol, err)
-				errors = append(errors, symbol+": "+err.Error())
-				failed++
-			} else {
-				updated++
-			}
-
-			// Rate limiting based on provider configuration
-			if len(request.Symbols) > 1 {
-				time.Sleep(s.providerService.GetRateLimitDelay())
-			}
-		}
+		result, err = s.providerService.UpdateSymbolPrices(ctx, request.Symbols)
 	}
 
+	if result == nil {
+		result = &providers.BulkPriceUpdateResult{}
+	}
+
+	success := err == nil && result.Updated > 0
 	response := map[string]interface{}{
-		"success": updated > 0,
-		"updated": updated,
-		"failed":  failed,
+		"success": success,
+		"updated": result.Updated,
+		"failed":  result.Failed,
 	}
 
-	if len(errors) > 0 {
-		response["errors"] = errors
+	if len(result.Errors) > 0 {
+		response["errors"] = result.Errors
 	}
 
-	if updated > 0 {
+	if err != nil {
+		response["message"] = err.Error()
+		log.Printf("%s Price update failed: %v", logPrefix, err)
+	} else if success {
 		response["message"] = "Price update completed"
+		log.Printf("%s Price update completed: %d updated, %d failed", logPrefix, result.Updated, result.Failed)
 	} else {
 		response["message"] = "No prices were updated"
+		log.Printf("%s Price update completed with no updates", logPrefix)
 	}
-
-	log.Printf("[POLYGON API] Price update completed: %d updated, %d failed", updated, failed)
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(response); err != nil {
-		log.Printf("[POLYGON API] Error encoding update response: %v", err)
+		log.Printf("%s Error encoding update response: %v", logPrefix, err)
 	}
 }
 
-// polygonSymbolInfoHandler gets detailed symbol information from Polygon
-func (s *Server) polygonSymbolInfoHandler(w http.ResponseWriter, r *http.Request) {
+// providerSymbolInfoHandler gets detailed symbol information from the configured provider
+func (s *Server) providerSymbolInfoHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
 	// Extract symbol from URL path
-	path := strings.TrimPrefix(r.URL.Path, "/api/polygon/symbol-info/")
+	path := strings.TrimPrefix(r.URL.Path, "/api/provider/symbol-info/")
 	if path == "" {
 		http.Error(w, "Symbol required", http.StatusBadRequest)
 		return
 	}
 
 	symbol := strings.ToUpper(path)
-	log.Printf("[POLYGON API] Getting symbol info for: %s", symbol)
+	logPrefix := s.providerLogPrefix()
+	log.Printf("%s Getting symbol info for: %s", logPrefix, symbol)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -161,7 +146,7 @@ func (s *Server) polygonSymbolInfoHandler(w http.ResponseWriter, r *http.Request
 	// Get symbol info from configured data provider
 	info, err := s.providerService.FetchSymbolDetails(ctx, symbol)
 	if err != nil {
-		log.Printf("[POLYGON API] Error getting symbol info for %s: %v", symbol, err)
+		log.Printf("%s Error getting symbol info for %s: %v", logPrefix, symbol, err)
 		response := map[string]interface{}{
 			"success": false,
 			"error":   err.Error(),
@@ -175,7 +160,7 @@ func (s *Server) polygonSymbolInfoHandler(w http.ResponseWriter, r *http.Request
 	// Get dividend history (optional)
 	dividends, err := s.providerService.FetchDividendHistory(ctx, symbol, 5)
 	if err != nil {
-		log.Printf("[POLYGON API] Warning: failed to get dividend history for %s: %v", symbol, err)
+		log.Printf("%s Warning: failed to get dividend history for %s: %v", logPrefix, symbol, err)
 		// Continue without dividends
 	}
 
@@ -188,22 +173,23 @@ func (s *Server) polygonSymbolInfoHandler(w http.ResponseWriter, r *http.Request
 		response["dividends"] = dividends
 	}
 
-	log.Printf("[POLYGON API] Successfully retrieved info for %s", symbol)
+	log.Printf("%s Successfully retrieved info for %s", logPrefix, symbol)
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(response); err != nil {
-		log.Printf("[POLYGON API] Error encoding symbol info response: %v", err)
+		log.Printf("%s Error encoding symbol info response: %v", logPrefix, err)
 	}
 }
 
-// polygonStatusHandler returns the status of the Polygon integration
-func (s *Server) polygonStatusHandler(w http.ResponseWriter, r *http.Request) {
+// providerStatusHandler returns the status of the provider integration
+func (s *Server) providerStatusHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
 	status := s.providerService.GetAPIKeyStatus()
+	logPrefix := s.providerLogPrefix()
 
 	// Test connection if API key is configured
 	if status.Configured {
@@ -220,18 +206,19 @@ func (s *Server) polygonStatusHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(status); err != nil {
-		log.Printf("[POLYGON API] Error encoding status response: %v", err)
+		log.Printf("%s Error encoding status response: %v", logPrefix, err)
 	}
 }
 
-// polygonFetchDividendsHandler fetches dividend data for all symbols
-func (s *Server) polygonFetchDividendsHandler(w http.ResponseWriter, r *http.Request) {
+// providerFetchDividendsHandler fetches dividend data for symbols
+func (s *Server) providerFetchDividendsHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
-	log.Printf("[POLYGON API] Starting bulk dividend fetch request")
+	logPrefix := s.providerLogPrefix()
+	log.Printf("%s Starting bulk dividend fetch request", logPrefix)
 
 	// Parse request body to get specific symbols (optional)
 	var request struct {
@@ -252,88 +239,49 @@ func (s *Server) polygonFetchDividendsHandler(w http.ResponseWriter, r *http.Req
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	var processed int
-	var results []map[string]interface{}
-	var errors []string
-
+	var symbols []string
 	if request.All || len(request.Symbols) == 0 {
-		// Fetch dividends for all symbols (prioritized: active positions first)
-		symbols, err := s.symbolService.GetPrioritizedSymbols()
+		var err error
+		symbols, err = s.symbolService.GetPrioritizedSymbols()
 		if err != nil {
-			log.Printf("[POLYGON API] Error getting prioritized symbols: %v", err)
+			log.Printf("%s Error getting prioritized symbols: %v", logPrefix, err)
 			http.Error(w, "Failed to get symbols", http.StatusInternalServerError)
 			return
 		}
-
-		log.Printf("[POLYGON API] Fetching dividends for %d symbols (prioritized order)", len(symbols))
-
-		for _, symbol := range symbols {
-			dividends, err := s.providerService.FetchDividendHistory(ctx, symbol, request.Limit)
-			processed++
-
-			if err != nil {
-				log.Printf("[POLYGON API] Failed to fetch dividends for %s: %v", symbol, err)
-				errors = append(errors, symbol+": "+err.Error())
-			} else {
-				results = append(results, map[string]interface{}{
-					"symbol":    symbol,
-					"dividends": dividends,
-					"count":     len(dividends),
-				})
-			}
-
-			// Rate limiting based on provider configuration
-			time.Sleep(s.providerService.GetRateLimitDelay())
-		}
 	} else {
-		// Fetch dividends for specific symbols
-		log.Printf("[POLYGON API] Fetching dividends for specific symbols: %v", request.Symbols)
+		symbols = request.Symbols
+	}
 
-		for _, symbol := range request.Symbols {
-			dividends, err := s.providerService.FetchDividendHistory(ctx, symbol, request.Limit)
-			processed++
-
-			if err != nil {
-				log.Printf("[POLYGON API] Failed to fetch dividends for %s: %v", symbol, err)
-				errors = append(errors, symbol+": "+err.Error())
-			} else {
-				results = append(results, map[string]interface{}{
-					"symbol":    symbol,
-					"dividends": dividends,
-					"count":     len(dividends),
-				})
-			}
-
-			// Rate limiting based on provider configuration
-			if len(request.Symbols) > 1 {
-				time.Sleep(s.providerService.GetRateLimitDelay())
-			}
-		}
+	result, err := s.providerService.FetchDividendHistoryForSymbols(ctx, symbols, request.Limit)
+	if result == nil {
+		result = &providers.BulkDividendFetchResult{}
 	}
 
 	response := map[string]interface{}{
-		"success":   true,
-		"processed": processed,
-		"results":   results,
+		"success":   err == nil,
+		"processed": result.Processed,
+		"results":   result.Results,
 	}
 
-	if len(errors) > 0 {
-		response["errors"] = errors
+	if len(result.Errors) > 0 {
+		response["errors"] = result.Errors
 	}
 
 	totalDividends := 0
-	for _, result := range results {
-		if count, ok := result["count"].(int); ok {
-			totalDividends += count
-		}
+	for _, record := range result.Results {
+		totalDividends += len(record.Dividends)
 	}
 
-	response["message"] = fmt.Sprintf("Dividend fetch completed: %d symbols processed, %d total dividends found", processed, totalDividends)
-
-	log.Printf("[POLYGON API] Dividend fetch completed: %d symbols processed, %d total dividends found", processed, totalDividends)
+	if err != nil {
+		response["message"] = err.Error()
+		log.Printf("%s Dividend fetch failed: %v", logPrefix, err)
+	} else {
+		response["message"] = fmt.Sprintf("Dividend fetch completed: %d symbols processed, %d total dividends found", result.Processed, totalDividends)
+		log.Printf("%s Dividend fetch completed: %d symbols processed, %d total dividends found", logPrefix, result.Processed, totalDividends)
+	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(response); err != nil {
-		log.Printf("[POLYGON API] Error encoding dividend fetch response: %v", err)
+		log.Printf("%s Error encoding dividend fetch response: %v", logPrefix, err)
 	}
 }

--- a/internal/web/provider_handlers.go
+++ b/internal/web/provider_handlers.go
@@ -26,12 +26,19 @@ func validateSymbols(symbols []string) ([]string, error) {
 	return validated, nil
 }
 
-func (s *Server) providerLogPrefix() string {
-	name := strings.ToUpper(strings.TrimSpace(s.providerService.Name()))
+func providerLogPrefix(providerService *providers.Service) string {
+	name := strings.ToUpper(strings.TrimSpace(providerService.Name()))
 	if name == "" {
 		name = "PROVIDER"
 	}
 	return fmt.Sprintf("[%s API]", name)
+}
+
+func (s *Server) providerServicesForRequest(r *http.Request) providerServicesSnapshot {
+	if snapshot, ok := providerServicesFromContext(r.Context()); ok {
+		return snapshot
+	}
+	return providerServicesSnapshot{providerService: s.providerService, symbolService: s.symbolService}
 }
 
 // providerTestHandler tests the data provider API connection
@@ -42,7 +49,7 @@ func (s *Server) providerTestHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	providerName := s.providerService.Name()
-	logPrefix := s.providerLogPrefix()
+	logPrefix := providerLogPrefix(s.providerService)
 	log.Printf("%s Testing API connection", logPrefix)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -76,7 +83,9 @@ func (s *Server) providerUpdatePricesHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	logPrefix := s.providerLogPrefix()
+	services := s.providerServicesForRequest(r)
+	providerService := services.providerService
+	logPrefix := providerLogPrefix(providerService)
 	log.Printf("%s Starting price update request", logPrefix)
 
 	// Parse request body to get specific symbols (optional)
@@ -101,14 +110,14 @@ func (s *Server) providerUpdatePricesHandler(w http.ResponseWriter, r *http.Requ
 	)
 
 	if request.All || len(request.Symbols) == 0 {
-		result, err = s.providerService.UpdateAllSymbolPrices(ctx)
+		result, err = providerService.UpdateAllSymbolPrices(ctx)
 	} else {
 		validated, validateErr := validateSymbols(request.Symbols)
 		if validateErr != nil {
 			http.Error(w, validateErr.Error(), http.StatusBadRequest)
 			return
 		}
-		result, err = s.providerService.UpdateSymbolPrices(ctx, validated)
+		result, err = providerService.UpdateSymbolPrices(ctx, validated)
 	}
 
 	if result == nil {
@@ -121,6 +130,7 @@ func (s *Server) providerUpdatePricesHandler(w http.ResponseWriter, r *http.Requ
 		"updated": result.Updated,
 		"failed":  result.Failed,
 		"skipped": result.Skipped,
+		"limit":   providers.BulkPriceUpdateLimit(),
 	}
 
 	if len(result.Errors) > 0 {
@@ -167,7 +177,7 @@ func (s *Server) providerSymbolInfoHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	symbol := instrument.Key()
-	logPrefix := s.providerLogPrefix()
+	logPrefix := providerLogPrefix(s.providerService)
 	log.Printf("%s Getting symbol info for: %s", logPrefix, symbol)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -220,7 +230,7 @@ func (s *Server) providerStatusHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	status := s.providerService.GetAPIKeyStatus()
-	logPrefix := s.providerLogPrefix()
+	logPrefix := providerLogPrefix(s.providerService)
 
 	// Keyless providers are ready to test without an API key.
 	if status.Ready {
@@ -245,9 +255,12 @@ func (s *Server) providerFetchDividendsHandler(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	logPrefix := s.providerLogPrefix()
+	services := s.providerServicesForRequest(r)
+	providerService := services.providerService
+	symbolService := services.symbolService
+	logPrefix := providerLogPrefix(providerService)
 	log.Printf("%s Starting bulk dividend fetch request", logPrefix)
-	if !s.providerService.ActiveProfile().SupportsDividends {
+	if !providerService.ActiveProfile().SupportsDividends {
 		http.Error(w, "The configured provider does not support dividend history", http.StatusConflict)
 		return
 	}
@@ -276,7 +289,7 @@ func (s *Server) providerFetchDividendsHandler(w http.ResponseWriter, r *http.Re
 	var symbols []string
 	if request.All || len(request.Symbols) == 0 {
 		var err error
-		symbols, err = s.symbolService.GetPrioritizedSymbols()
+		symbols, err = symbolService.GetPrioritizedSymbols()
 		if err != nil {
 			log.Printf("%s Error getting prioritized symbols: %v", logPrefix, err)
 			http.Error(w, "Failed to get symbols", http.StatusInternalServerError)
@@ -291,7 +304,7 @@ func (s *Server) providerFetchDividendsHandler(w http.ResponseWriter, r *http.Re
 		symbols = validated
 	}
 
-	result, err := s.providerService.FetchDividendHistoryForSymbols(ctx, symbols, request.Limit)
+	result, err := providerService.FetchDividendHistoryForSymbols(ctx, symbols, request.Limit)
 	if result == nil {
 		result = &providers.BulkDividendFetchResult{Results: []providers.DividendFetchRecord{}}
 	}
@@ -299,6 +312,8 @@ func (s *Server) providerFetchDividendsHandler(w http.ResponseWriter, r *http.Re
 	response := map[string]interface{}{
 		"success":   err == nil,
 		"processed": result.Processed,
+		"skipped":   result.Skipped,
+		"limit":     providers.BulkPriceUpdateLimit(),
 		"results":   result.Results,
 	}
 
@@ -316,6 +331,9 @@ func (s *Server) providerFetchDividendsHandler(w http.ResponseWriter, r *http.Re
 		log.Printf("%s Dividend fetch failed: %v", logPrefix, err)
 	} else {
 		response["message"] = fmt.Sprintf("Dividend fetch completed: %d symbols processed, %d total dividends found", result.Processed, totalDividends)
+		if result.Skipped > 0 {
+			response["message"] = fmt.Sprintf("Dividend fetch completed: %d symbols processed, %d total dividends found; %d symbols remain for a later request", result.Processed, totalDividends, result.Skipped)
+		}
 		log.Printf("%s Dividend fetch completed: %d symbols processed, %d total dividends found", logPrefix, result.Processed, totalDividends)
 	}
 

--- a/internal/web/provider_handlers.go
+++ b/internal/web/provider_handlers.go
@@ -6,11 +6,14 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 
 	"stonks/internal/providers"
 )
+
+var symbolPattern = regexp.MustCompile(`^[A-Z0-9.\-]{1,10}$`)
 
 func (s *Server) providerLogPrefix() string {
 	name := strings.ToUpper(strings.TrimSpace(s.providerService.Name()))
@@ -137,6 +140,10 @@ func (s *Server) providerSymbolInfoHandler(w http.ResponseWriter, r *http.Reques
 	}
 
 	symbol := strings.ToUpper(path)
+	if !symbolPattern.MatchString(symbol) {
+		http.Error(w, "Invalid symbol", http.StatusBadRequest)
+		return
+	}
 	logPrefix := s.providerLogPrefix()
 	log.Printf("%s Getting symbol info for: %s", logPrefix, symbol)
 
@@ -254,7 +261,7 @@ func (s *Server) providerFetchDividendsHandler(w http.ResponseWriter, r *http.Re
 
 	result, err := s.providerService.FetchDividendHistoryForSymbols(ctx, symbols, request.Limit)
 	if result == nil {
-		result = &providers.BulkDividendFetchResult{}
+		result = &providers.BulkDividendFetchResult{Results: []providers.DividendFetchRecord{}}
 	}
 
 	response := map[string]interface{}{

--- a/internal/web/provider_handlers.go
+++ b/internal/web/provider_handlers.go
@@ -4,16 +4,27 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
-	"regexp"
+	"stonks/internal/markets"
 	"strings"
 	"time"
 
 	"stonks/internal/providers"
 )
 
-var symbolPattern = regexp.MustCompile(`^[A-Z0-9.\-]{1,10}$`)
+func validateSymbols(symbols []string) ([]string, error) {
+	validated := make([]string, 0, len(symbols))
+	for _, raw := range symbols {
+		instrument, err := markets.Parse(raw)
+		if err != nil {
+			return nil, fmt.Errorf("invalid symbol %q: %w", raw, err)
+		}
+		validated = append(validated, instrument.Key())
+	}
+	return validated, nil
+}
 
 func (s *Server) providerLogPrefix() string {
 	name := strings.ToUpper(strings.TrimSpace(s.providerService.Name()))
@@ -48,7 +59,7 @@ func (s *Server) providerTestHandler(w http.ResponseWriter, r *http.Request) {
 		response["error"] = err.Error()
 		log.Printf("%s Connection test failed: %v", logPrefix, err)
 	} else {
-		response["message"] = "API key is valid and connection successful"
+		response["message"] = "Provider connection successful"
 		log.Printf("%s Connection test successful", logPrefix)
 	}
 
@@ -74,9 +85,11 @@ func (s *Server) providerUpdatePricesHandler(w http.ResponseWriter, r *http.Requ
 		All     bool     `json:"all,omitempty"`
 	}
 
-	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
-		// If decoding fails, default to updating all symbols
+	if err := json.NewDecoder(r.Body).Decode(&request); err == io.EOF {
 		request.All = true
+	} else if err != nil {
+		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		return
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
@@ -90,7 +103,12 @@ func (s *Server) providerUpdatePricesHandler(w http.ResponseWriter, r *http.Requ
 	if request.All || len(request.Symbols) == 0 {
 		result, err = s.providerService.UpdateAllSymbolPrices(ctx)
 	} else {
-		result, err = s.providerService.UpdateSymbolPrices(ctx, request.Symbols)
+		validated, validateErr := validateSymbols(request.Symbols)
+		if validateErr != nil {
+			http.Error(w, validateErr.Error(), http.StatusBadRequest)
+			return
+		}
+		result, err = s.providerService.UpdateSymbolPrices(ctx, validated)
 	}
 
 	if result == nil {
@@ -102,6 +120,7 @@ func (s *Server) providerUpdatePricesHandler(w http.ResponseWriter, r *http.Requ
 		"success": success,
 		"updated": result.Updated,
 		"failed":  result.Failed,
+		"skipped": result.Skipped,
 	}
 
 	if len(result.Errors) > 0 {
@@ -113,6 +132,9 @@ func (s *Server) providerUpdatePricesHandler(w http.ResponseWriter, r *http.Requ
 		log.Printf("%s Price update failed: %v", logPrefix, err)
 	} else if success {
 		response["message"] = "Price update completed"
+		if result.Skipped > 0 {
+			response["message"] = fmt.Sprintf("Price update completed; %d symbols remain for a later request", result.Skipped)
+		}
 		log.Printf("%s Price update completed: %d updated, %d failed", logPrefix, result.Updated, result.Failed)
 	} else {
 		response["message"] = "No prices were updated"
@@ -139,11 +161,12 @@ func (s *Server) providerSymbolInfoHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	symbol := strings.ToUpper(path)
-	if !symbolPattern.MatchString(symbol) {
-		http.Error(w, "Invalid symbol", http.StatusBadRequest)
+	instrument, err := markets.Parse(path)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	symbol := instrument.Key()
 	logPrefix := s.providerLogPrefix()
 	log.Printf("%s Getting symbol info for: %s", logPrefix, symbol)
 
@@ -164,11 +187,12 @@ func (s *Server) providerSymbolInfoHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Get dividend history (optional)
-	dividends, err := s.providerService.FetchDividendHistory(ctx, symbol, 5)
-	if err != nil {
-		log.Printf("%s Warning: failed to get dividend history for %s: %v", logPrefix, symbol, err)
-		// Continue without dividends
+	var dividends []*providers.DividendInfo
+	if s.providerService.ActiveProfile().SupportsDividends {
+		dividends, err = s.providerService.FetchDividendHistory(ctx, symbol, 5)
+		if err != nil {
+			log.Printf("%s Warning: failed to get dividend history for %s: %v", logPrefix, symbol, err)
+		}
 	}
 
 	response := map[string]interface{}{
@@ -198,17 +222,14 @@ func (s *Server) providerStatusHandler(w http.ResponseWriter, r *http.Request) {
 	status := s.providerService.GetAPIKeyStatus()
 	logPrefix := s.providerLogPrefix()
 
-	// Test connection if API key is configured
-	if status.Configured {
+	// Keyless providers are ready to test without an API key.
+	if status.Ready {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
-		if err := s.providerService.TestConnection(ctx); err != nil {
-			status.Valid = false
-			status.Error = err.Error()
-		} else {
-			status.Valid = true
-		}
+		status.Valid, status.Error = s.cachedProviderValidation(status.Provider, func() error {
+			return s.providerService.TestConnection(ctx)
+		})
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -226,6 +247,10 @@ func (s *Server) providerFetchDividendsHandler(w http.ResponseWriter, r *http.Re
 
 	logPrefix := s.providerLogPrefix()
 	log.Printf("%s Starting bulk dividend fetch request", logPrefix)
+	if !s.providerService.ActiveProfile().SupportsDividends {
+		http.Error(w, "The configured provider does not support dividend history", http.StatusConflict)
+		return
+	}
 
 	// Parse request body to get specific symbols (optional)
 	var request struct {
@@ -234,9 +259,11 @@ func (s *Server) providerFetchDividendsHandler(w http.ResponseWriter, r *http.Re
 		Limit   int      `json:"limit,omitempty"`
 	}
 
-	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
-		// If decoding fails, default to fetching all symbols
+	if err := json.NewDecoder(r.Body).Decode(&request); err == io.EOF {
 		request.All = true
+	} else if err != nil {
+		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		return
 	}
 
 	if request.Limit == 0 {
@@ -256,7 +283,12 @@ func (s *Server) providerFetchDividendsHandler(w http.ResponseWriter, r *http.Re
 			return
 		}
 	} else {
-		symbols = request.Symbols
+		validated, validateErr := validateSymbols(request.Symbols)
+		if validateErr != nil {
+			http.Error(w, validateErr.Error(), http.StatusBadRequest)
+			return
+		}
+		symbols = validated
 	}
 
 	result, err := s.providerService.FetchDividendHistoryForSymbols(ctx, symbols, request.Limit)

--- a/internal/web/provider_integration_test.go
+++ b/internal/web/provider_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"stonks/internal/database"
 	"stonks/internal/providers"
@@ -97,6 +98,25 @@ func TestProviderUpdateRejectsMalformedJSON(t *testing.T) {
 	}
 }
 
+func TestProviderUpdateResponseExposesBulkLimit(t *testing.T) {
+	server, _ := newProviderTestServer(t, "provider-update-limit")
+	request := httptest.NewRequest(http.MethodPost, "/api/provider/update-prices", strings.NewReader(`{"all":true}`))
+	recorder := httptest.NewRecorder()
+	server.providerUpdatePricesHandler(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("provider update = %d: %s", recorder.Code, recorder.Body.String())
+	}
+	var response struct {
+		Limit int `json:"limit"`
+	}
+	if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+	if response.Limit != providers.BulkPriceUpdateLimit() {
+		t.Fatalf("response limit = %d, want %d", response.Limit, providers.BulkPriceUpdateLimit())
+	}
+}
+
 func TestProviderSymbolValidation(t *testing.T) {
 	valid, err := validateSymbols([]string{" nasdaq:aapl ", "nasdaq:msft", "NYSE:BRK.B"})
 	if err != nil {
@@ -169,12 +189,14 @@ func TestProviderValidationCache(t *testing.T) {
 func TestProviderValidationCacheCoalescesConcurrentRequests(t *testing.T) {
 	server := &Server{}
 	started := make(chan struct{})
+	waiting := make(chan struct{})
 	release := make(chan struct{})
 	results := make(chan struct {
 		valid bool
 		err   string
 	}, 2)
 	checks := 0
+	server.providerValidationWaitHook = func() { close(waiting) }
 	validate := func() error {
 		checks++
 		close(started)
@@ -198,6 +220,9 @@ func TestProviderValidationCacheCoalescesConcurrentRequests(t *testing.T) {
 		}{valid, errText}
 	}()
 
+	// Do not release the first validation until the second request has entered
+	// the in-flight wait path. This proves coalescing rather than a cache hit.
+	<-waiting
 	close(release)
 	for range 2 {
 		result := <-results
@@ -210,12 +235,42 @@ func TestProviderValidationCacheCoalescesConcurrentRequests(t *testing.T) {
 	}
 }
 
+func TestDatabaseSwitchDoesNotWaitForLeasedProviderServices(t *testing.T) {
+	server, first := newProviderTestServer(t, "leased-first")
+	_, release := server.acquireProviderServices()
+
+	second, err := database.NewDB(filepath.Join(t.TempDir(), "leased-second.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = second.Close() })
+
+	done := make(chan error, 1)
+	go func() { done <- server.switchServices(second.DB) }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("database switch waited for the leased provider request")
+	}
+	if err := first.DB.Ping(); err != nil {
+		t.Fatalf("leased database was closed during provider request: %v", err)
+	}
+
+	release()
+	if err := first.DB.Ping(); err == nil {
+		t.Fatal("retired database remained open after provider request completed")
+	}
+}
+
 func TestProviderConfigurationTemplateContainsAllProviderControls(t *testing.T) {
 	contents, err := os.ReadFile("templates/settings.html")
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, value := range []string{"providerTypeInput", "apiKeyField", "noApiKeyField", "Dividend history:"} {
+	for _, value := range []string{"providerTypeInput", "apiKeyField", "noApiKeyField", "Dividend history:", "Market selection required", "LegacySymbols", "savedProviderType", "Unsaved provider selection"} {
 		if !strings.Contains(string(contents), value) {
 			t.Errorf("settings template is missing %q", value)
 		}
@@ -242,8 +297,42 @@ func TestSymbolModalQualifiesLegacySymbols(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(contents), "this.editingSymbol.includes(':')") || !strings.Contains(string(contents), "/qualify") {
+	if !strings.Contains(string(contents), "this.editingSymbol.includes(':')") || !strings.Contains(string(contents), "/qualify") || !strings.Contains(string(contents), "response.text()") {
 		t.Fatal("symbol modal does not route legacy edits through the qualification endpoint")
+	}
+}
+
+func TestSymbolProviderOperationsNormalizePathSymbols(t *testing.T) {
+	server, _ := newProviderTestServer(t, "symbol-provider-normalization")
+	for name, handler := range map[string]func(http.ResponseWriter, *http.Request, string){
+		"update price":    server.symbolUpdatePriceHandler,
+		"fetch dividends": server.symbolFetchDividendsHandler,
+	} {
+		t.Run(name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodPost, "/api/symbols/nasdaq:aapl", nil)
+			recorder := httptest.NewRecorder()
+			handler(recorder, request, "nasdaq:aapl")
+
+			var response struct {
+				Symbol string `json:"symbol"`
+			}
+			if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+				t.Fatal(err)
+			}
+			if response.Symbol != "NASDAQ:AAPL" {
+				t.Fatalf("symbol = %q, want NASDAQ:AAPL", response.Symbol)
+			}
+		})
+	}
+}
+
+func TestSymbolTemplateRestoresMarketAfterOptionsLoad(t *testing.T) {
+	contents, err := os.ReadFile("templates/symbol.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(contents), "selectedMarket") || !strings.Contains(string(contents), "marketInput.value = selectedMarket") {
+		t.Fatal("symbol template does not restore the selected market after loading options")
 	}
 }
 

--- a/internal/web/provider_integration_test.go
+++ b/internal/web/provider_integration_test.go
@@ -1,0 +1,263 @@
+package web
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"stonks/internal/database"
+	"stonks/internal/providers"
+)
+
+func newProviderTestServer(t *testing.T, name string) (*Server, *database.DB) {
+	t.Helper()
+	db, err := database.NewDB(filepath.Join(t.TempDir(), name+".db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	server := &Server{}
+	server.initializeServices(db.DB)
+	return server, db
+}
+
+func TestProviderSettingValidation(t *testing.T) {
+	server, _ := newProviderTestServer(t, "settings")
+
+	request := httptest.NewRequest(http.MethodPut, "/api/settings/DATA_PROVIDER_TYPE", strings.NewReader(`{"value":"google","description":""}`))
+	recorder := httptest.NewRecorder()
+	server.updateSettingAPI(recorder, request, "DATA_PROVIDER_TYPE")
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected valid provider update, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+	if got := server.settingService.GetValue("DATA_PROVIDER_TYPE"); got != "google_finance" {
+		t.Fatalf("expected canonical provider type, got %q", got)
+	}
+
+	request = httptest.NewRequest(http.MethodPut, "/api/settings/DATA_PROVIDER_TYPE", strings.NewReader(`{"value":"not-a-provider"}`))
+	recorder = httptest.NewRecorder()
+	server.updateSettingAPI(recorder, request, "DATA_PROVIDER_TYPE")
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected invalid provider to be rejected, got %d", recorder.Code)
+	}
+}
+
+func TestProviderServiceIsRecreatedForNewDatabase(t *testing.T) {
+	server, first := newProviderTestServer(t, "first")
+	if err := server.settingService.SetValue("DATA_PROVIDER_TYPE", "google_finance", ""); err != nil {
+		t.Fatal(err)
+	}
+	if got := server.providerService.Name(); got != "google_finance" {
+		t.Fatalf("first database provider = %q", got)
+	}
+
+	second, err := database.NewDB(filepath.Join(t.TempDir(), "second.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = second.Close() })
+	if err := server.switchServices(second.DB); err != nil {
+		t.Fatal(err)
+	}
+	if err := server.settingService.SetValue("DATA_PROVIDER_TYPE", "yfinance", ""); err != nil {
+		t.Fatal(err)
+	}
+	if got := server.providerService.Name(); got != "yfinance" {
+		t.Fatalf("provider service retained first database configuration: %q", got)
+	}
+	_ = first
+}
+
+func TestGoogleFinanceDividendEndpointIsDisabled(t *testing.T) {
+	server, _ := newProviderTestServer(t, "google-dividends")
+	if err := server.settingService.SetValue("DATA_PROVIDER_TYPE", "google_finance", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	request := httptest.NewRequest(http.MethodPost, "/api/provider/fetch-dividends", bytes.NewBufferString(`{"symbols":["AAPL"]}`))
+	recorder := httptest.NewRecorder()
+	server.providerFetchDividendsHandler(recorder, request)
+	if recorder.Code != http.StatusConflict {
+		t.Fatalf("expected unsupported dividends response, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestProviderUpdateRejectsMalformedJSON(t *testing.T) {
+	server, _ := newProviderTestServer(t, "malformed-provider-update")
+	request := httptest.NewRequest(http.MethodPost, "/api/provider/update-prices", strings.NewReader(`{"all":`))
+	recorder := httptest.NewRecorder()
+	server.providerUpdatePricesHandler(recorder, request)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected malformed JSON to be rejected, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestProviderSymbolValidation(t *testing.T) {
+	valid, err := validateSymbols([]string{" nasdaq:aapl ", "nasdaq:msft", "NYSE:BRK.B"})
+	if err != nil {
+		t.Fatalf("expected valid symbols, got %v", err)
+	}
+	want := []string{"NASDAQ:AAPL", "NASDAQ:MSFT", "NYSE:BRK.B"}
+	if strings.Join(valid, ",") != strings.Join(want, ",") {
+		t.Fatalf("validated symbols = %v, want %v", valid, want)
+	}
+
+	if _, err := validateSymbols([]string{"NASDAQ:AAPL", "../../etc/passwd"}); err == nil || !strings.Contains(err.Error(), "../../etc/passwd") {
+		t.Fatalf("expected invalid symbol to be identified, got %v", err)
+	}
+}
+
+func TestProviderConfigurationIsAtomic(t *testing.T) {
+	server, _ := newProviderTestServer(t, "provider-configuration")
+	if err := server.settingService.SetValue("DATA_PROVIDER_TYPE", "yfinance", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	request := httptest.NewRequest(http.MethodPut, "/api/provider/configuration", strings.NewReader(`{"provider_type":"polygon","polygon_api_key":""}`))
+	recorder := httptest.NewRecorder()
+	server.providerConfigurationAPIHandler(recorder, request)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected missing Polygon key to be rejected, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+	if got := server.settingService.GetValue("DATA_PROVIDER_TYPE"); got != "yfinance" {
+		t.Fatalf("failed configuration activated provider %q", got)
+	}
+
+	request = httptest.NewRequest(http.MethodPut, "/api/provider/configuration", strings.NewReader(`{"provider_type":"google"}`))
+	recorder = httptest.NewRecorder()
+	server.providerConfigurationAPIHandler(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected Google configuration to succeed, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+	if got := server.settingService.GetValue("DATA_PROVIDER_TYPE"); got != "google_finance" {
+		t.Fatalf("provider = %q, want google_finance", got)
+	}
+}
+
+func TestProviderValidationCache(t *testing.T) {
+	server := &Server{}
+	checks := 0
+	validate := func() error {
+		checks++
+		return nil
+	}
+
+	for range 2 {
+		valid, errText := server.cachedProviderValidation("yfinance", validate)
+		if !valid || errText != "" {
+			t.Fatalf("unexpected validation result: valid=%v error=%q", valid, errText)
+		}
+	}
+	if checks != 1 {
+		t.Fatalf("expected cached validation to run once, ran %d times", checks)
+	}
+
+	server.invalidateProviderValidation()
+	if valid, errText := server.cachedProviderValidation("yfinance", validate); !valid || errText != "" {
+		t.Fatalf("unexpected validation after invalidation: valid=%v error=%q", valid, errText)
+	}
+	if checks != 2 {
+		t.Fatalf("expected invalidated validation to run again, ran %d times", checks)
+	}
+}
+
+func TestProviderValidationCacheCoalescesConcurrentRequests(t *testing.T) {
+	server := &Server{}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	results := make(chan struct {
+		valid bool
+		err   string
+	}, 2)
+	checks := 0
+	validate := func() error {
+		checks++
+		close(started)
+		<-release
+		return nil
+	}
+
+	go func() {
+		valid, errText := server.cachedProviderValidation("yfinance", validate)
+		results <- struct {
+			valid bool
+			err   string
+		}{valid, errText}
+	}()
+	<-started
+	go func() {
+		valid, errText := server.cachedProviderValidation("yfinance", validate)
+		results <- struct {
+			valid bool
+			err   string
+		}{valid, errText}
+	}()
+
+	close(release)
+	for range 2 {
+		result := <-results
+		if !result.valid || result.err != "" {
+			t.Fatalf("unexpected validation result: %+v", result)
+		}
+	}
+	if checks != 1 {
+		t.Fatalf("expected one concurrent validation request, got %d", checks)
+	}
+}
+
+func TestProviderConfigurationTemplateContainsAllProviderControls(t *testing.T) {
+	contents, err := os.ReadFile("templates/settings.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, value := range []string{"providerTypeInput", "apiKeyField", "noApiKeyField", "Dividend history:"} {
+		if !strings.Contains(string(contents), value) {
+			t.Errorf("settings template is missing %q", value)
+		}
+	}
+
+	profileJSON, err := json.Marshal(providers.ProviderProfiles())
+	if err != nil || !strings.Contains(string(profileJSON), "google_finance") || !strings.Contains(string(profileJSON), "yfinance") {
+		t.Fatalf("provider profiles cannot be represented for the settings UI: %s, %v", profileJSON, err)
+	}
+}
+
+func TestSymbolModalRequiresMarketSelection(t *testing.T) {
+	contents, err := os.ReadFile("templates/_symbol_modal.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(contents), `id="marketInput"`) || !strings.Contains(string(contents), "MARKET:TICKER") {
+		t.Fatalf("symbol modal does not expose the market selection: %s", contents)
+	}
+}
+
+func TestSymbolModalQualifiesLegacySymbols(t *testing.T) {
+	contents, err := os.ReadFile("static/js/symbol-modal.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(contents), "this.editingSymbol.includes(':')") || !strings.Contains(string(contents), "/qualify") {
+		t.Fatal("symbol modal does not route legacy edits through the qualification endpoint")
+	}
+}
+
+func TestMarketsAPIListsCanonicalMarkets(t *testing.T) {
+	server, _ := newProviderTestServer(t, "markets")
+	request := httptest.NewRequest(http.MethodGet, "/api/markets", nil)
+	recorder := httptest.NewRecorder()
+	server.marketsAPIHandler(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("markets endpoint = %d", recorder.Code)
+	}
+	for _, market := range []string{"NASDAQ", "NYSE", "NYSEARCA", "BVMF"} {
+		if !strings.Contains(recorder.Body.String(), market) {
+			t.Fatalf("markets response does not include %s: %s", market, recorder.Body.String())
+		}
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -9,10 +9,10 @@ import (
 	"net/http"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"stonks/internal/database"
 	"stonks/internal/models"
 	"stonks/internal/providers"
+	"strconv"
 	"strings"
 	"time"
 
@@ -51,7 +51,7 @@ func NewServer() (*Server, error) {
 	// Load templates with custom functions
 	templatePath := filepath.Join("internal", "web", "templates", "*.html")
 	log.Printf("[SERVER] Loading HTML templates from: %s", templatePath)
-	
+
 	// Create template with custom functions
 	funcMap := template.FuncMap{
 		"groupByExpiration": groupPositionsByExpiration,
@@ -119,19 +119,19 @@ func NewServer() (*Server, error) {
 			default:
 				return "$0"
 			}
-			
+
 			// Round to nearest whole number
 			rounded := int64(floatVal + 0.5)
 			if floatVal < 0 {
 				rounded = int64(floatVal - 0.5)
 			}
-			
+
 			// Format with commas
 			str := fmt.Sprintf("%d", rounded)
 			if rounded < 0 {
 				str = str[1:] // Remove negative sign temporarily
 			}
-			
+
 			// Add commas
 			if len(str) > 3 {
 				var result string
@@ -143,7 +143,7 @@ func NewServer() (*Server, error) {
 				}
 				str = result
 			}
-			
+
 			if floatVal < 0 {
 				return "-$" + str
 			}
@@ -165,22 +165,22 @@ func NewServer() (*Server, error) {
 			default:
 				return "$0.00"
 			}
-			
+
 			// Format to 2 decimal places
 			formatted := fmt.Sprintf("%.2f", floatVal)
-			
+
 			// Split into integer and decimal parts
 			parts := strings.Split(formatted, ".")
 			intPart := parts[0]
 			decPart := parts[1]
-			
+
 			// Handle negative numbers
 			isNegative := false
 			if strings.HasPrefix(intPart, "-") {
 				isNegative = true
 				intPart = intPart[1:]
 			}
-			
+
 			// Add commas to integer part
 			if len(intPart) > 3 {
 				var result string
@@ -192,7 +192,7 @@ func NewServer() (*Server, error) {
 				}
 				intPart = result
 			}
-			
+
 			// Combine with decimals
 			formatted = intPart + "." + decPart
 			if isNegative {
@@ -210,14 +210,14 @@ func NewServer() (*Server, error) {
 			default:
 				return "0"
 			}
-			
+
 			str := fmt.Sprintf("%d", intVal)
 			isNegative := false
 			if intVal < 0 {
 				isNegative = true
 				str = str[1:]
 			}
-			
+
 			// Add commas
 			if len(str) > 3 {
 				var result string
@@ -229,14 +229,14 @@ func NewServer() (*Server, error) {
 				}
 				str = result
 			}
-			
+
 			if isNegative {
 				return "-" + str
 			}
 			return str
 		},
 	}
-	
+
 	templates, err := template.New("").Funcs(funcMap).ParseGlob(templatePath)
 	if err != nil {
 		log.Printf("[SERVER] ERROR: Failed to parse templates: %v", err)
@@ -245,11 +245,11 @@ func NewServer() (*Server, error) {
 	log.Printf("[SERVER] HTML templates loaded successfully")
 
 	log.Printf("[SERVER] Initializing service layers")
-	
+
 	// Initialize core services
 	symbolService := models.NewSymbolService(dbWrapper.DB)
 	settingService := models.NewSettingService(dbWrapper.DB)
-	
+
 	server := &Server{
 		db:                  dbWrapper.DB,
 		optionService:       models.NewOptionService(dbWrapper.DB),
@@ -426,20 +426,20 @@ func (s *Server) setupRoutes() {
 	http.HandleFunc("/api/settings/", s.individualSettingAPIHandler)
 	log.Printf("[SERVER] Route registered: /api/settings/ -> individualSettingAPIHandler")
 
-	http.HandleFunc("/api/polygon/test", s.polygonTestHandler)
-	log.Printf("[SERVER] Route registered: /api/polygon/test -> polygonTestHandler")
+	http.HandleFunc("/api/provider/test", s.providerTestHandler)
+	log.Printf("[SERVER] Route registered: /api/provider/test -> providerTestHandler")
 
-	http.HandleFunc("/api/polygon/update-prices", s.polygonUpdatePricesHandler)
-	log.Printf("[SERVER] Route registered: /api/polygon/update-prices -> polygonUpdatePricesHandler")
+	http.HandleFunc("/api/provider/update-prices", s.providerUpdatePricesHandler)
+	log.Printf("[SERVER] Route registered: /api/provider/update-prices -> providerUpdatePricesHandler")
 
-	http.HandleFunc("/api/polygon/symbol-info/", s.polygonSymbolInfoHandler)
-	log.Printf("[SERVER] Route registered: /api/polygon/symbol-info/ -> polygonSymbolInfoHandler")
+	http.HandleFunc("/api/provider/symbol-info/", s.providerSymbolInfoHandler)
+	log.Printf("[SERVER] Route registered: /api/provider/symbol-info/ -> providerSymbolInfoHandler")
 
-	http.HandleFunc("/api/polygon/status", s.polygonStatusHandler)
-	log.Printf("[SERVER] Route registered: /api/polygon/status -> polygonStatusHandler")
+	http.HandleFunc("/api/provider/status", s.providerStatusHandler)
+	log.Printf("[SERVER] Route registered: /api/provider/status -> providerStatusHandler")
 
-	http.HandleFunc("/api/polygon/fetch-dividends", s.polygonFetchDividendsHandler)
-	log.Printf("[SERVER] Route registered: /api/polygon/fetch-dividends -> polygonFetchDividendsHandler")
+	http.HandleFunc("/api/provider/fetch-dividends", s.providerFetchDividendsHandler)
+	log.Printf("[SERVER] Route registered: /api/provider/fetch-dividends -> providerFetchDividendsHandler")
 
 	log.Printf("[SERVER] All routes registered successfully")
 }
@@ -472,13 +472,13 @@ type ExpirationGroup struct {
 // groupPositionsByExpiration groups open positions by expiration date and returns them sorted
 func groupPositionsByExpiration(positions []*models.OpenPositionData) []ExpirationGroup {
 	grouped := make(map[time.Time][]*models.OpenPositionData)
-	
+
 	// Group positions by expiration date
 	for _, position := range positions {
 		expDate := position.Expiration
 		grouped[expDate] = append(grouped[expDate], position)
 	}
-	
+
 	// Convert to slice and sort by expiration date
 	var groups []ExpirationGroup
 	for expDate, posGroup := range grouped {
@@ -490,25 +490,25 @@ func groupPositionsByExpiration(positions []*models.OpenPositionData) []Expirati
 			}
 			return posI.Strike < posJ.Strike
 		})
-		
+
 		groups = append(groups, ExpirationGroup{
 			Expiration: expDate,
 			DateStr:    expDate.Format("01/02/2006"),
 			Positions:  posGroup,
 		})
 	}
-	
+
 	// Sort groups by expiration date (earliest first)
 	sort.Slice(groups, func(i, j int) bool {
 		return groups[i].Expiration.Before(groups[j].Expiration)
 	})
-	
+
 	return groups
 }
 
 func (s *Server) renderTemplate(w http.ResponseWriter, templateName string, data interface{}) {
 	log.Printf("[TEMPLATE] Starting template execution for: %s", templateName)
-	
+
 	// Use a buffer to execute template first, then write to response if successful
 	var buf bytes.Buffer
 	err := s.templates.ExecuteTemplate(&buf, templateName, data)
@@ -517,7 +517,7 @@ func (s *Server) renderTemplate(w http.ResponseWriter, templateName string, data
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
-	
+
 	// Template executed successfully, write to response
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	_, err = w.Write(buf.Bytes())

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -12,7 +12,7 @@ import (
 	"strconv"
 	"stonks/internal/database"
 	"stonks/internal/models"
-	"stonks/internal/polygon"
+	"stonks/internal/providers"
 	"strings"
 	"time"
 
@@ -28,7 +28,7 @@ type Server struct {
 	dividendService     *models.DividendService
 	settingService      *models.SettingService
 	metricService       *models.MetricService
-	polygonService      *polygon.Service
+	providerService     *providers.Service
 	templates           *template.Template
 }
 
@@ -259,7 +259,7 @@ func NewServer() (*Server, error) {
 		dividendService:     models.NewDividendService(dbWrapper.DB),
 		settingService:      settingService,
 		metricService:       models.NewMetricService(dbWrapper.DB),
-		polygonService:      polygon.NewService(symbolService, settingService),
+		providerService:     providers.NewService(symbolService, settingService),
 		templates:           templates,
 	}
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -14,22 +14,41 @@ import (
 	"stonks/internal/providers"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	_ "github.com/mattn/go-sqlite3"
 )
 
 type Server struct {
-	db                  *sql.DB
-	optionService       *models.OptionService
-	symbolService       *models.SymbolService
-	treasuryService     *models.TreasuryService
-	longPositionService *models.LongPositionService
-	dividendService     *models.DividendService
-	settingService      *models.SettingService
-	metricService       *models.MetricService
-	providerService     *providers.Service
-	templates           *template.Template
+	servicesMu                   sync.RWMutex
+	db                           *sql.DB
+	optionService                *models.OptionService
+	symbolService                *models.SymbolService
+	treasuryService              *models.TreasuryService
+	longPositionService          *models.LongPositionService
+	dividendService              *models.DividendService
+	settingService               *models.SettingService
+	metricService                *models.MetricService
+	providerService              *providers.Service
+	providerValidation           map[string]providerValidationCacheEntry
+	providerValidationInFlight   map[string]*providerValidationCall
+	providerValidationGeneration uint64
+	providerValidationMu         sync.Mutex
+	templates                    *template.Template
+}
+
+const providerValidationCacheTTL = time.Minute
+
+type providerValidationCacheEntry struct {
+	checkedAt time.Time
+	valid     bool
+	err       string
+}
+
+type providerValidationCall struct {
+	done       chan struct{}
+	generation uint64
 }
 
 func NewServer() (*Server, error) {
@@ -246,22 +265,11 @@ func NewServer() (*Server, error) {
 
 	log.Printf("[SERVER] Initializing service layers")
 
-	// Initialize core services
-	symbolService := models.NewSymbolService(dbWrapper.DB)
-	settingService := models.NewSettingService(dbWrapper.DB)
-
 	server := &Server{
-		db:                  dbWrapper.DB,
-		optionService:       models.NewOptionService(dbWrapper.DB),
-		symbolService:       symbolService,
-		treasuryService:     models.NewTreasuryService(dbWrapper.DB),
-		longPositionService: models.NewLongPositionService(dbWrapper.DB),
-		dividendService:     models.NewDividendService(dbWrapper.DB),
-		settingService:      settingService,
-		metricService:       models.NewMetricService(dbWrapper.DB),
-		providerService:     providers.NewService(symbolService, settingService),
-		templates:           templates,
+		db:        dbWrapper.DB,
+		templates: templates,
 	}
+	server.initializeServices(dbWrapper.DB)
 
 	log.Printf("[SERVER] All services initialized successfully")
 	log.Printf("[SERVER] Server creation completed")
@@ -269,11 +277,113 @@ func NewServer() (*Server, error) {
 	return server, nil
 }
 
+// initializeServices binds every server service to the supplied database.
+// It is used at startup and after a database switch to avoid stale service
+// pointers, including provider configuration from the previous database.
+func (s *Server) initializeServices(db *sql.DB) {
+	s.servicesMu.Lock()
+	defer s.servicesMu.Unlock()
+	s.initializeServicesLocked(db)
+	s.invalidateProviderValidation()
+}
+
+func (s *Server) initializeServicesLocked(db *sql.DB) {
+	s.db = db
+	s.optionService = models.NewOptionService(db)
+	s.symbolService = models.NewSymbolService(db)
+	s.treasuryService = models.NewTreasuryService(db)
+	s.longPositionService = models.NewLongPositionService(db)
+	s.dividendService = models.NewDividendService(db)
+	s.settingService = models.NewSettingService(db)
+	s.metricService = models.NewMetricService(db)
+	s.providerService = providers.NewService(s.symbolService, s.settingService)
+}
+
+func (s *Server) cachedProviderValidation(provider string, validate func() error) (bool, string) {
+	for {
+		s.providerValidationMu.Lock()
+		generation := s.providerValidationGeneration
+		if entry, ok := s.providerValidation[provider]; ok && time.Since(entry.checkedAt) < providerValidationCacheTTL {
+			s.providerValidationMu.Unlock()
+			return entry.valid, entry.err
+		}
+		if call, ok := s.providerValidationInFlight[provider]; ok && call.generation == generation {
+			done := call.done
+			s.providerValidationMu.Unlock()
+			<-done
+			continue
+		}
+		if s.providerValidationInFlight == nil {
+			s.providerValidationInFlight = make(map[string]*providerValidationCall)
+		}
+		call := &providerValidationCall{done: make(chan struct{}), generation: generation}
+		s.providerValidationInFlight[provider] = call
+		s.providerValidationMu.Unlock()
+
+		entry := providerValidationCacheEntry{checkedAt: time.Now()}
+		if err := validate(); err != nil {
+			entry.err = err.Error()
+		} else {
+			entry.valid = true
+		}
+
+		s.providerValidationMu.Lock()
+		if s.providerValidationGeneration == generation {
+			if s.providerValidation == nil {
+				s.providerValidation = make(map[string]providerValidationCacheEntry)
+			}
+			s.providerValidation[provider] = entry
+		}
+		if s.providerValidationInFlight[provider] == call {
+			delete(s.providerValidationInFlight, provider)
+			close(call.done)
+		}
+		isCurrentGeneration := s.providerValidationGeneration == generation
+		s.providerValidationMu.Unlock()
+		if isCurrentGeneration {
+			return entry.valid, entry.err
+		}
+	}
+}
+
+func (s *Server) invalidateProviderValidation() {
+	s.providerValidationMu.Lock()
+	defer s.providerValidationMu.Unlock()
+	s.providerValidation = make(map[string]providerValidationCacheEntry)
+	s.providerValidationGeneration++
+}
+
 // Close closes the database connection
 func (s *Server) Close() error {
+	s.servicesMu.Lock()
+	defer s.servicesMu.Unlock()
 	if s.db != nil {
 		log.Printf("[SERVER] Closing database connection")
 		return s.db.Close()
+	}
+	return nil
+}
+
+func (s *Server) handleServiceFunc(pattern string, handler http.HandlerFunc) {
+	http.HandleFunc(pattern, func(w http.ResponseWriter, r *http.Request) {
+		s.servicesMu.RLock()
+		defer s.servicesMu.RUnlock()
+		handler(w, r)
+	})
+}
+
+// switchServices atomically replaces the service set after all in-flight
+// service handlers complete, then closes the old database before new handlers
+// can observe it.
+func (s *Server) switchServices(db *sql.DB) error {
+	s.servicesMu.Lock()
+	defer s.servicesMu.Unlock()
+
+	oldDB := s.db
+	s.initializeServicesLocked(db)
+	s.invalidateProviderValidation()
+	if oldDB != nil && oldDB != db {
+		return oldDB.Close()
 	}
 	return nil
 }
@@ -285,58 +395,58 @@ func (s *Server) setupRoutes() {
 	http.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.Dir("internal/web/static"))))
 	log.Printf("[SERVER] Route registered: /static/ -> file server")
 
-	http.HandleFunc("/", s.dashboardHandler)
+	s.handleServiceFunc("/", s.dashboardHandler)
 	log.Printf("[SERVER] Route registered: / -> dashboardHandler")
 
-	http.HandleFunc("/monthly", s.monthlyHandler)
+	s.handleServiceFunc("/monthly", s.monthlyHandler)
 	log.Printf("[SERVER] Route registered: /monthly -> monthlyHandler")
 
-	http.HandleFunc("/options", s.optionsHandler)
+	s.handleServiceFunc("/options", s.optionsHandler)
 	log.Printf("[SERVER] Route registered: /options -> optionsHandler")
 
-	http.HandleFunc("/all-options", s.allOptionsHandler)
+	s.handleServiceFunc("/all-options", s.allOptionsHandler)
 	log.Printf("[SERVER] Route registered: /all-options -> allOptionsHandler")
 
-	http.HandleFunc("/treasuries", s.treasuriesHandler)
+	s.handleServiceFunc("/treasuries", s.treasuriesHandler)
 	log.Printf("[SERVER] Route registered: /treasuries -> treasuriesHandler")
 
-	http.HandleFunc("/dividends", s.dividendsHandler)
+	s.handleServiceFunc("/dividends", s.dividendsHandler)
 	log.Printf("[SERVER] Route registered: /dividends -> dividendsHandler")
 
-	http.HandleFunc("/metrics", s.metricsHandler)
+	s.handleServiceFunc("/metrics", s.metricsHandler)
 	log.Printf("[SERVER] Route registered: /metrics -> metricsHandler")
 
-	http.HandleFunc("/zen", s.zenHandler)
+	s.handleServiceFunc("/zen", s.zenHandler)
 	log.Printf("[SERVER] Route registered: /zen -> zenHandler")
 
-	http.HandleFunc("/symbol/", s.symbolHandler)
+	s.handleServiceFunc("/symbol/", s.symbolHandler)
 	log.Printf("[SERVER] Route registered: /symbol/ -> symbolHandler")
 
-	http.HandleFunc("/api/premium-data", s.premiumDataHandler)
+	s.handleServiceFunc("/api/premium-data", s.premiumDataHandler)
 	log.Printf("[SERVER] Route registered: /api/premium-data -> premiumDataHandler")
 
-	http.HandleFunc("/api/options", s.optionAPIHandler)
+	s.handleServiceFunc("/api/options", s.optionAPIHandler)
 	log.Printf("[SERVER] Route registered: /api/options -> optionAPIHandler")
 
-	http.HandleFunc("/api/options/", s.individualOptionAPIHandler)
+	s.handleServiceFunc("/api/options/", s.individualOptionAPIHandler)
 	log.Printf("[SERVER] Route registered: /api/options/ -> individualOptionAPIHandler")
 
-	http.HandleFunc("/api/options/filter", s.optionsFilterHandler)
+	s.handleServiceFunc("/api/options/filter", s.optionsFilterHandler)
 	log.Printf("[SERVER] Route registered: /api/options/filter -> optionsFilterHandler")
 
-	http.HandleFunc("/api/symbols/", s.symbolAPIHandler)
+	s.handleServiceFunc("/api/symbols/", s.symbolAPIHandler)
 	log.Printf("[SERVER] Route registered: /api/symbols/ -> symbolAPIHandler")
 
-	http.HandleFunc("/api/dividends", s.dividendsAPIHandler)
+	s.handleServiceFunc("/api/dividends", s.dividendsAPIHandler)
 	log.Printf("[SERVER] Route registered: /api/dividends -> dividendsAPIHandler")
 
-	http.HandleFunc("/api/long-positions", s.longPositionsAPIHandler)
+	s.handleServiceFunc("/api/long-positions", s.longPositionsAPIHandler)
 	log.Printf("[SERVER] Route registered: /api/long-positions -> longPositionsAPIHandler")
 
-	http.HandleFunc("/api/treasuries/", s.treasuryAPIHandler)
+	s.handleServiceFunc("/api/treasuries/", s.treasuryAPIHandler)
 	log.Printf("[SERVER] Route registered: /api/treasuries/ -> treasuryAPIHandler")
 
-	http.HandleFunc("/api/metrics", func(w http.ResponseWriter, r *http.Request) {
+	s.handleServiceFunc("/api/metrics", func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet:
 			s.getMetricsHandler(w, r)
@@ -348,7 +458,7 @@ func (s *Server) setupRoutes() {
 	})
 	log.Printf("[SERVER] Route registered: /api/metrics -> metrics API handler")
 
-	http.HandleFunc("/api/metrics/", func(w http.ResponseWriter, r *http.Request) {
+	s.handleServiceFunc("/api/metrics/", func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodPut:
 			s.updateMetricHandler(w, r)
@@ -360,85 +470,91 @@ func (s *Server) setupRoutes() {
 	})
 	log.Printf("[SERVER] Route registered: /api/metrics/ -> individual metric API handler")
 
-	http.HandleFunc("/api/metrics/snapshot", s.createMetricsSnapshotHandler)
+	s.handleServiceFunc("/api/metrics/snapshot", s.createMetricsSnapshotHandler)
 	log.Printf("[SERVER] Route registered: /api/metrics/snapshot -> createMetricsSnapshotHandler")
 
-	http.HandleFunc("/api/metrics/chart-data", s.getMetricsChartDataHandler)
+	s.handleServiceFunc("/api/metrics/chart-data", s.getMetricsChartDataHandler)
 	log.Printf("[SERVER] Route registered: /api/metrics/chart-data -> getMetricsChartDataHandler")
 
-	http.HandleFunc("/add-option", s.addOptionHandler)
+	s.handleServiceFunc("/add-option", s.addOptionHandler)
 	log.Printf("[SERVER] Route registered: /add-option -> addOptionHandler")
 
-	http.HandleFunc("/add-treasury", s.addTreasuryHandler)
+	s.handleServiceFunc("/add-treasury", s.addTreasuryHandler)
 	log.Printf("[SERVER] Route registered: /add-treasury -> addTreasuryHandler")
 
-	http.HandleFunc("/api/allocation-data", s.allocationDataHandler)
+	s.handleServiceFunc("/api/allocation-data", s.allocationDataHandler)
 	log.Printf("[SERVER] Route registered: /api/allocation-data -> allocationDataHandler")
 
-	http.HandleFunc("/api/optionable-positions", s.optionablePositionsHandler)
+	s.handleServiceFunc("/api/optionable-positions", s.optionablePositionsHandler)
 	log.Printf("[SERVER] Route registered: /api/optionable-positions -> optionablePositionsHandler")
 
-	http.HandleFunc("/import", s.HandleImport)
+	s.handleServiceFunc("/import", s.HandleImport)
 	log.Printf("[SERVER] Route registered: /import -> HandleImport")
 
-	http.HandleFunc("/backup", s.HandleBackup)
+	s.handleServiceFunc("/backup", s.HandleBackup)
 	log.Printf("[SERVER] Route registered: /backup -> HandleBackup")
 
-	http.HandleFunc("/backup/", s.HandleBackupFile)
+	s.handleServiceFunc("/backup/", s.HandleBackupFile)
 	log.Printf("[SERVER] Route registered: /backup/ -> HandleBackupFile")
 
 	http.HandleFunc("/database/set-current", s.handleSetCurrentDatabase)
 	log.Printf("[SERVER] Route registered: /database/set-current -> handleSetCurrentDatabase")
 
-	http.HandleFunc("/database/create", s.handleCreateDatabase)
+	s.handleServiceFunc("/database/create", s.handleCreateDatabase)
 	log.Printf("[SERVER] Route registered: /database/create -> handleCreateDatabase")
 
-	http.HandleFunc("/database/delete/", s.handleDeleteDatabase)
+	s.handleServiceFunc("/database/delete/", s.handleDeleteDatabase)
 	log.Printf("[SERVER] Route registered: /database/delete/ -> handleDeleteDatabase")
 
 	http.Handle("/backups/", http.StripPrefix("/backups/", http.FileServer(http.Dir("./data/backups"))))
 	log.Printf("[SERVER] Route registered: /backups/ -> file server for backup directory")
 
-	http.HandleFunc("/import/upload", s.HandleImportUpload)
+	s.handleServiceFunc("/import/upload", s.HandleImportUpload)
 	log.Printf("[SERVER] Route registered: /import/upload -> HandleImportUpload")
 
-	http.HandleFunc("/import/upload/stocks", s.HandleStocksImportUpload)
+	s.handleServiceFunc("/import/upload/stocks", s.HandleStocksImportUpload)
 	log.Printf("[SERVER] Route registered: /import/upload/stocks -> HandleStocksImportUpload")
 
-	http.HandleFunc("/import/upload/dividends", s.HandleDividendsImportUpload)
+	s.handleServiceFunc("/import/upload/dividends", s.HandleDividendsImportUpload)
 	log.Printf("[SERVER] Route registered: /import/upload/dividends -> HandleDividendsImportUpload")
 
-	http.HandleFunc("/import/upload/treasuries", s.HandleTreasuriesImportUpload)
+	s.handleServiceFunc("/import/upload/treasuries", s.HandleTreasuriesImportUpload)
 	log.Printf("[SERVER] Route registered: /import/upload/treasuries -> HandleTreasuriesImportUpload")
 
-	http.HandleFunc("/api/generate-test-data", s.HandleGenerateTestData)
+	s.handleServiceFunc("/api/generate-test-data", s.HandleGenerateTestData)
 	log.Printf("[SERVER] Route registered: /api/generate-test-data -> HandleGenerateTestData")
 
-	http.HandleFunc("/help", s.helpHandler)
+	s.handleServiceFunc("/help", s.helpHandler)
 	log.Printf("[SERVER] Route registered: /help -> helpHandler")
 
-	http.HandleFunc("/settings", s.settingsHandler)
+	s.handleServiceFunc("/settings", s.settingsHandler)
 	log.Printf("[SERVER] Route registered: /settings -> settingsHandler")
 
-	http.HandleFunc("/api/settings", s.settingsAPIHandler)
+	s.handleServiceFunc("/api/settings", s.settingsAPIHandler)
 	log.Printf("[SERVER] Route registered: /api/settings -> settingsAPIHandler")
 
-	http.HandleFunc("/api/settings/", s.individualSettingAPIHandler)
+	s.handleServiceFunc("/api/settings/", s.individualSettingAPIHandler)
 	log.Printf("[SERVER] Route registered: /api/settings/ -> individualSettingAPIHandler")
 
-	http.HandleFunc("/api/provider/test", s.providerTestHandler)
+	s.handleServiceFunc("/api/provider/configuration", s.providerConfigurationAPIHandler)
+	log.Printf("[SERVER] Route registered: /api/provider/configuration -> providerConfigurationAPIHandler")
+
+	s.handleServiceFunc("/api/markets", s.marketsAPIHandler)
+	log.Printf("[SERVER] Route registered: /api/markets -> marketsAPIHandler")
+
+	s.handleServiceFunc("/api/provider/test", s.providerTestHandler)
 	log.Printf("[SERVER] Route registered: /api/provider/test -> providerTestHandler")
 
-	http.HandleFunc("/api/provider/update-prices", s.providerUpdatePricesHandler)
+	s.handleServiceFunc("/api/provider/update-prices", s.providerUpdatePricesHandler)
 	log.Printf("[SERVER] Route registered: /api/provider/update-prices -> providerUpdatePricesHandler")
 
-	http.HandleFunc("/api/provider/symbol-info/", s.providerSymbolInfoHandler)
+	s.handleServiceFunc("/api/provider/symbol-info/", s.providerSymbolInfoHandler)
 	log.Printf("[SERVER] Route registered: /api/provider/symbol-info/ -> providerSymbolInfoHandler")
 
-	http.HandleFunc("/api/provider/status", s.providerStatusHandler)
+	s.handleServiceFunc("/api/provider/status", s.providerStatusHandler)
 	log.Printf("[SERVER] Route registered: /api/provider/status -> providerStatusHandler")
 
-	http.HandleFunc("/api/provider/fetch-dividends", s.providerFetchDividendsHandler)
+	s.handleServiceFunc("/api/provider/fetch-dividends", s.providerFetchDividendsHandler)
 	log.Printf("[SERVER] Route registered: /api/provider/fetch-dividends -> providerFetchDividendsHandler")
 
 	log.Printf("[SERVER] All routes registered successfully")

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"bytes"
+	"context"
 	"database/sql"
 	"fmt"
 	"html/template"
@@ -31,10 +32,13 @@ type Server struct {
 	settingService               *models.SettingService
 	metricService                *models.MetricService
 	providerService              *providers.Service
+	serviceLeases                map[*sql.DB]int
+	retiredDatabases             map[*sql.DB]struct{}
 	providerValidation           map[string]providerValidationCacheEntry
 	providerValidationInFlight   map[string]*providerValidationCall
 	providerValidationGeneration uint64
 	providerValidationMu         sync.Mutex
+	providerValidationWaitHook   func()
 	templates                    *template.Template
 }
 
@@ -50,6 +54,13 @@ type providerValidationCall struct {
 	done       chan struct{}
 	generation uint64
 }
+
+type providerServicesSnapshot struct {
+	providerService *providers.Service
+	symbolService   *models.SymbolService
+}
+
+type providerServicesContextKey struct{}
 
 func NewServer() (*Server, error) {
 	log.Printf("[SERVER] Initializing Wheeler web server")
@@ -303,13 +314,22 @@ func (s *Server) cachedProviderValidation(provider string, validate func() error
 	for {
 		s.providerValidationMu.Lock()
 		generation := s.providerValidationGeneration
+		// A fresh entry is safe to return immediately. Cache invalidation bumps
+		// the generation, so entries from an earlier provider configuration are
+		// never reused after a settings or database change.
 		if entry, ok := s.providerValidation[provider]; ok && time.Since(entry.checkedAt) < providerValidationCacheTTL {
 			s.providerValidationMu.Unlock()
 			return entry.valid, entry.err
 		}
+		// One caller validates outside the mutex. Other callers wait for that
+		// result instead of serializing multiple provider HTTP requests.
 		if call, ok := s.providerValidationInFlight[provider]; ok && call.generation == generation {
 			done := call.done
+			waitHook := s.providerValidationWaitHook
 			s.providerValidationMu.Unlock()
+			if waitHook != nil {
+				waitHook()
+			}
 			<-done
 			continue
 		}
@@ -320,6 +340,8 @@ func (s *Server) cachedProviderValidation(provider string, validate func() error
 		s.providerValidationInFlight[provider] = call
 		s.providerValidationMu.Unlock()
 
+		// This request owns the validation for this provider and generation.
+		// Never hold providerValidationMu across the potentially slow HTTP call.
 		entry := providerValidationCacheEntry{checkedAt: time.Now()}
 		if err := validate(); err != nil {
 			entry.err = err.Error()
@@ -343,9 +365,14 @@ func (s *Server) cachedProviderValidation(provider string, validate func() error
 		if isCurrentGeneration {
 			return entry.valid, entry.err
 		}
+		// Configuration changed while validation was in progress. Repeat using
+		// the current generation rather than returning a stale result.
 	}
 }
 
+// invalidateProviderValidation makes cached and in-flight validations from a
+// previous configuration obsolete. In-flight callers wake their waiters, which
+// retry against this newer generation.
 func (s *Server) invalidateProviderValidation() {
 	s.providerValidationMu.Lock()
 	defer s.providerValidationMu.Unlock()
@@ -372,9 +399,53 @@ func (s *Server) handleServiceFunc(pattern string, handler http.HandlerFunc) {
 	})
 }
 
-// switchServices atomically replaces the service set after all in-flight
-// service handlers complete, then closes the old database before new handlers
-// can observe it.
+// handleProviderServiceFunc leases the current provider services for long bulk
+// requests. The lease keeps their database open after a switch, but does not
+// hold servicesMu while network and rate-limit waits are in progress.
+func (s *Server) handleProviderServiceFunc(pattern string, handler http.HandlerFunc) {
+	http.HandleFunc(pattern, func(w http.ResponseWriter, r *http.Request) {
+		snapshot, release := s.acquireProviderServices()
+		defer release()
+		ctx := context.WithValue(r.Context(), providerServicesContextKey{}, snapshot)
+		handler(w, r.WithContext(ctx))
+	})
+}
+
+func (s *Server) acquireProviderServices() (providerServicesSnapshot, func()) {
+	s.servicesMu.Lock()
+	db := s.db
+	if s.serviceLeases == nil {
+		s.serviceLeases = make(map[*sql.DB]int)
+	}
+	s.serviceLeases[db]++
+	snapshot := providerServicesSnapshot{providerService: s.providerService, symbolService: s.symbolService}
+	s.servicesMu.Unlock()
+
+	return snapshot, func() {
+		s.servicesMu.Lock()
+		defer s.servicesMu.Unlock()
+		s.serviceLeases[db]--
+		if s.serviceLeases[db] != 0 {
+			return
+		}
+		delete(s.serviceLeases, db)
+		if _, retired := s.retiredDatabases[db]; retired {
+			delete(s.retiredDatabases, db)
+			if err := db.Close(); err != nil {
+				log.Printf("[SERVER] Error closing retired database: %v", err)
+			}
+		}
+	}
+}
+
+func providerServicesFromContext(ctx context.Context) (providerServicesSnapshot, bool) {
+	snapshot, ok := ctx.Value(providerServicesContextKey{}).(providerServicesSnapshot)
+	return snapshot, ok
+}
+
+// switchServices atomically replaces the service set. A database leased by a
+// long provider request is closed by that request's release function instead
+// of delaying the switch or invalidating the in-flight request.
 func (s *Server) switchServices(db *sql.DB) error {
 	s.servicesMu.Lock()
 	defer s.servicesMu.Unlock()
@@ -383,6 +454,13 @@ func (s *Server) switchServices(db *sql.DB) error {
 	s.initializeServicesLocked(db)
 	s.invalidateProviderValidation()
 	if oldDB != nil && oldDB != db {
+		if s.serviceLeases[oldDB] > 0 {
+			if s.retiredDatabases == nil {
+				s.retiredDatabases = make(map[*sql.DB]struct{})
+			}
+			s.retiredDatabases[oldDB] = struct{}{}
+			return nil
+		}
 		return oldDB.Close()
 	}
 	return nil
@@ -545,7 +623,7 @@ func (s *Server) setupRoutes() {
 	s.handleServiceFunc("/api/provider/test", s.providerTestHandler)
 	log.Printf("[SERVER] Route registered: /api/provider/test -> providerTestHandler")
 
-	s.handleServiceFunc("/api/provider/update-prices", s.providerUpdatePricesHandler)
+	s.handleProviderServiceFunc("/api/provider/update-prices", s.providerUpdatePricesHandler)
 	log.Printf("[SERVER] Route registered: /api/provider/update-prices -> providerUpdatePricesHandler")
 
 	s.handleServiceFunc("/api/provider/symbol-info/", s.providerSymbolInfoHandler)
@@ -554,7 +632,7 @@ func (s *Server) setupRoutes() {
 	s.handleServiceFunc("/api/provider/status", s.providerStatusHandler)
 	log.Printf("[SERVER] Route registered: /api/provider/status -> providerStatusHandler")
 
-	s.handleServiceFunc("/api/provider/fetch-dividends", s.providerFetchDividendsHandler)
+	s.handleProviderServiceFunc("/api/provider/fetch-dividends", s.providerFetchDividendsHandler)
 	log.Printf("[SERVER] Route registered: /api/provider/fetch-dividends -> providerFetchDividendsHandler")
 
 	log.Printf("[SERVER] All routes registered successfully")

--- a/internal/web/settings_handlers.go
+++ b/internal/web/settings_handlers.go
@@ -62,6 +62,10 @@ func formatProviderDisplayName(raw string) string {
 	switch lower {
 	case "polygon":
 		return "Polygon.io"
+	case "google_finance":
+		return "Google Finance"
+	case "yfinance":
+		return "Yahoo Finance (yfinance)"
 	default:
 		runes := []rune(trimmed)
 		runes[0] = unicode.ToUpper(runes[0])

--- a/internal/web/settings_handlers.go
+++ b/internal/web/settings_handlers.go
@@ -5,17 +5,18 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"strings"
 	"stonks/internal/models"
+	"strings"
 )
 
 // SettingsData holds data for the settings template
 type SettingsData struct {
-	Settings   []*models.Setting `json:"settings"`
-	AllSymbols []string          `json:"allSymbols"`
-	CurrentDB  string            `json:"currentDB"`
-	ApiKey     string            `json:"apiKey"`
-	ActivePage string            `json:"activePage"`
+	Settings     []*models.Setting `json:"settings"`
+	AllSymbols   []string          `json:"allSymbols"`
+	CurrentDB    string            `json:"currentDB"`
+	ApiKey       string            `json:"apiKey"`
+	ProviderName string            `json:"providerName"`
+	ActivePage   string            `json:"activePage"`
 }
 
 // settingsHandler serves the settings management page
@@ -40,14 +41,31 @@ func (s *Server) settingsHandler(w http.ResponseWriter, r *http.Request) {
 	apiKey := s.settingService.GetValue("POLYGON_API_KEY")
 
 	data := SettingsData{
-		Settings:   settings,
-		AllSymbols: symbols,
-		CurrentDB:  s.getCurrentDatabaseName(),
-		ApiKey:     apiKey,
-		ActivePage: "settings",
+		Settings:     settings,
+		AllSymbols:   symbols,
+		CurrentDB:    s.getCurrentDatabaseName(),
+		ApiKey:       apiKey,
+		ProviderName: formatProviderDisplayName(s.providerService.Name()),
+		ActivePage:   "settings",
 	}
 
 	s.renderTemplate(w, "settings.html", data)
+}
+
+func formatProviderDisplayName(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "Market Data Provider"
+	}
+	lower := strings.ToLower(trimmed)
+	switch lower {
+	case "polygon":
+		return "Polygon.io"
+	default:
+		runes := []rune(trimmed)
+		runes[0] = []rune(strings.ToUpper(string(runes[0])))[0]
+		return string(runes)
+	}
 }
 
 // settingsAPIHandler handles CRUD operations for settings collection

--- a/internal/web/settings_handlers.go
+++ b/internal/web/settings_handlers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"stonks/internal/markets"
 	"stonks/internal/models"
 	"stonks/internal/providers"
 	"strings"
@@ -15,6 +16,7 @@ import (
 type SettingsData struct {
 	Settings         []*models.Setting           `json:"settings"`
 	AllSymbols       []string                    `json:"allSymbols"`
+	LegacySymbols    []string                    `json:"legacySymbols"`
 	CurrentDB        string                      `json:"currentDB"`
 	ApiKey           string                      `json:"apiKey"`
 	ActiveProvider   string                      `json:"activeProvider"`
@@ -32,6 +34,12 @@ func (s *Server) settingsHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Printf("[SETTINGS] Error getting symbols: %v", err)
 		symbols = []string{}
+	}
+	legacySymbols := make([]string, 0)
+	for _, symbol := range symbols {
+		if markets.IsLegacyKey(symbol) {
+			legacySymbols = append(legacySymbols, symbol)
+		}
 	}
 
 	// Get all settings
@@ -51,6 +59,7 @@ func (s *Server) settingsHandler(w http.ResponseWriter, r *http.Request) {
 	data := SettingsData{
 		Settings:         settings,
 		AllSymbols:       symbols,
+		LegacySymbols:    legacySymbols,
 		CurrentDB:        s.getCurrentDatabaseName(),
 		ApiKey:           apiKey,
 		ActiveProvider:   s.providerService.Name(),
@@ -189,11 +198,17 @@ func (s *Server) providerConfigurationAPIHandler(w http.ResponseWriter, r *http.
 		return
 	}
 	profile := providers.ProviderProfile{}
+	foundProfile := false
 	for _, candidate := range providers.ProviderProfiles() {
 		if candidate.ID == providerType {
 			profile = candidate
+			foundProfile = true
 			break
 		}
+	}
+	if !foundProfile {
+		http.Error(w, fmt.Sprintf("unsupported data provider type: %s", providerType), http.StatusBadRequest)
+		return
 	}
 
 	apiKey := strings.TrimSpace(req.PolygonAPIKey)
@@ -216,6 +231,7 @@ func (s *Server) providerConfigurationAPIHandler(w http.ResponseWriter, r *http.
 	}
 	if profile.RequiresAPIKey {
 		if err := upsert("POLYGON_API_KEY", apiKey, "API key for Polygon.io stock market data integration"); err != nil {
+			log.Printf("[SETTINGS API] Error saving Polygon API key: %v", err)
 			http.Error(w, "Failed to save provider configuration", http.StatusInternalServerError)
 			return
 		}
@@ -223,6 +239,7 @@ func (s *Server) providerConfigurationAPIHandler(w http.ResponseWriter, r *http.
 	// Write the active provider last. The transaction makes every change
 	// visible together only after all dependent configuration has succeeded.
 	if err := upsert("DATA_PROVIDER_TYPE", providerType, "Active market data provider"); err != nil {
+		log.Printf("[SETTINGS API] Error saving provider type: %v", err)
 		http.Error(w, "Failed to save provider configuration", http.StatusInternalServerError)
 		return
 	}

--- a/internal/web/settings_handlers.go
+++ b/internal/web/settings_handlers.go
@@ -6,18 +6,21 @@ import (
 	"log"
 	"net/http"
 	"stonks/internal/models"
+	"stonks/internal/providers"
 	"strings"
 	"unicode"
 )
 
 // SettingsData holds data for the settings template
 type SettingsData struct {
-	Settings     []*models.Setting `json:"settings"`
-	AllSymbols   []string          `json:"allSymbols"`
-	CurrentDB    string            `json:"currentDB"`
-	ApiKey       string            `json:"apiKey"`
-	ProviderName string            `json:"providerName"`
-	ActivePage   string            `json:"activePage"`
+	Settings         []*models.Setting           `json:"settings"`
+	AllSymbols       []string                    `json:"allSymbols"`
+	CurrentDB        string                      `json:"currentDB"`
+	ApiKey           string                      `json:"apiKey"`
+	ActiveProvider   string                      `json:"activeProvider"`
+	ProviderName     string                      `json:"providerName"`
+	ProviderProfiles []providers.ProviderProfile `json:"providerProfiles"`
+	ActivePage       string                      `json:"activePage"`
 }
 
 // settingsHandler serves the settings management page
@@ -38,16 +41,22 @@ func (s *Server) settingsHandler(w http.ResponseWriter, r *http.Request) {
 		settings = []*models.Setting{}
 	}
 
-	// Get API key value specifically
-	apiKey := s.settingService.GetValue("POLYGON_API_KEY")
+	profile := s.providerService.ActiveProfile()
+	providerName := profile.DisplayName
+	if providerName == "" {
+		providerName = formatProviderDisplayName(s.providerService.Name())
+	}
 
+	apiKey := s.settingService.GetValue("POLYGON_API_KEY")
 	data := SettingsData{
-		Settings:     settings,
-		AllSymbols:   symbols,
-		CurrentDB:    s.getCurrentDatabaseName(),
-		ApiKey:       apiKey,
-		ProviderName: formatProviderDisplayName(s.providerService.Name()),
-		ActivePage:   "settings",
+		Settings:         settings,
+		AllSymbols:       symbols,
+		CurrentDB:        s.getCurrentDatabaseName(),
+		ApiKey:           apiKey,
+		ActiveProvider:   s.providerService.Name(),
+		ProviderName:     providerName,
+		ProviderProfiles: providers.ProviderProfiles(),
+		ActivePage:       "settings",
 	}
 
 	s.renderTemplate(w, "settings.html", data)
@@ -154,6 +163,80 @@ type SettingRequest struct {
 	Description string `json:"description"`
 }
 
+// ProviderConfigurationRequest groups settings that must change together when
+// selecting a market-data provider. Keeping this separate from the generic
+// settings CRUD API makes a provider switch atomic.
+type ProviderConfigurationRequest struct {
+	ProviderType  string `json:"provider_type"`
+	PolygonAPIKey string `json:"polygon_api_key"`
+}
+
+func (s *Server) providerConfigurationAPIHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPut {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req ProviderConfigurationRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	providerType, ok := providers.CanonicalProviderType(req.ProviderType)
+	if !ok {
+		http.Error(w, fmt.Sprintf("unsupported data provider type: %s", strings.TrimSpace(req.ProviderType)), http.StatusBadRequest)
+		return
+	}
+	profile := providers.ProviderProfile{}
+	for _, candidate := range providers.ProviderProfiles() {
+		if candidate.ID == providerType {
+			profile = candidate
+			break
+		}
+	}
+
+	apiKey := strings.TrimSpace(req.PolygonAPIKey)
+	if profile.RequiresAPIKey && apiKey == "" {
+		http.Error(w, "Polygon API key is required when Polygon.io is selected", http.StatusBadRequest)
+		return
+	}
+	tx, err := s.db.BeginTx(r.Context(), nil)
+	if err != nil {
+		log.Printf("[SETTINGS API] Error starting provider configuration transaction: %v", err)
+		http.Error(w, "Failed to save provider configuration", http.StatusInternalServerError)
+		return
+	}
+	defer tx.Rollback()
+
+	upsert := func(name, value, description string) error {
+		_, err := tx.Exec(`INSERT INTO settings (name, value, description) VALUES (?, ?, ?)
+			ON CONFLICT(name) DO UPDATE SET value = excluded.value, description = excluded.description, updated_at = CURRENT_TIMESTAMP`, name, value, description)
+		return err
+	}
+	if profile.RequiresAPIKey {
+		if err := upsert("POLYGON_API_KEY", apiKey, "API key for Polygon.io stock market data integration"); err != nil {
+			http.Error(w, "Failed to save provider configuration", http.StatusInternalServerError)
+			return
+		}
+	}
+	// Write the active provider last. The transaction makes every change
+	// visible together only after all dependent configuration has succeeded.
+	if err := upsert("DATA_PROVIDER_TYPE", providerType, "Active market data provider"); err != nil {
+		http.Error(w, "Failed to save provider configuration", http.StatusInternalServerError)
+		return
+	}
+	if err := tx.Commit(); err != nil {
+		log.Printf("[SETTINGS API] Error committing provider configuration: %v", err)
+		http.Error(w, "Failed to save provider configuration", http.StatusInternalServerError)
+		return
+	}
+
+	s.invalidateProviderValidation()
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"provider": providerType})
+}
+
 // createSettingAPI creates a new setting
 func (s *Server) createSettingAPI(w http.ResponseWriter, r *http.Request) {
 	var req SettingRequest
@@ -166,6 +249,10 @@ func (s *Server) createSettingAPI(w http.ResponseWriter, r *http.Request) {
 	// Validate required fields
 	if strings.TrimSpace(req.Name) == "" {
 		http.Error(w, "Setting name is required", http.StatusBadRequest)
+		return
+	}
+	if err := normalizeProviderSetting(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -182,6 +269,7 @@ func (s *Server) createSettingAPI(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.Printf("[SETTINGS API] Successfully created setting: %s", setting.Name)
+	s.invalidateProviderValidation()
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
@@ -198,6 +286,11 @@ func (s *Server) updateSettingAPI(w http.ResponseWriter, r *http.Request, name s
 		http.Error(w, "Invalid JSON", http.StatusBadRequest)
 		return
 	}
+	req.Name = name
+	if err := normalizeProviderSetting(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 
 	// Update the setting
 	setting, err := s.settingService.Update(name, req.Value, req.Description)
@@ -212,11 +305,30 @@ func (s *Server) updateSettingAPI(w http.ResponseWriter, r *http.Request, name s
 	}
 
 	log.Printf("[SETTINGS API] Successfully updated setting: %s", setting.Name)
+	s.invalidateProviderValidation()
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(setting); err != nil {
 		log.Printf("[SETTINGS API] Error encoding update response: %v", err)
 	}
+}
+
+func normalizeProviderSetting(req *SettingRequest) error {
+	name := strings.ToUpper(strings.TrimSpace(req.Name))
+	switch name {
+	case "DATA_PROVIDER_TYPE":
+		providerType, ok := providers.CanonicalProviderType(req.Value)
+		if !ok {
+			return fmt.Errorf("unsupported data provider type: %s", strings.TrimSpace(req.Value))
+		}
+		req.Value = providerType
+	case "GOOGLE_FINANCE_EXCHANGE":
+		req.Value = strings.ToUpper(strings.TrimSpace(req.Value))
+		if req.Value == "" {
+			req.Value = "NASDAQ"
+		}
+	}
+	return nil
 }
 
 // deleteSettingAPI deletes a setting
@@ -233,6 +345,7 @@ func (s *Server) deleteSettingAPI(w http.ResponseWriter, r *http.Request, name s
 	}
 
 	log.Printf("[SETTINGS API] Successfully deleted setting: %s", name)
+	s.invalidateProviderValidation()
 
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/web/settings_handlers.go
+++ b/internal/web/settings_handlers.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"stonks/internal/models"
 	"strings"
+	"unicode"
 )
 
 // SettingsData holds data for the settings template
@@ -63,7 +64,7 @@ func formatProviderDisplayName(raw string) string {
 		return "Polygon.io"
 	default:
 		runes := []rune(trimmed)
-		runes[0] = []rune(strings.ToUpper(string(runes[0])))[0]
+		runes[0] = unicode.ToUpper(runes[0])
 		return string(runes)
 	}
 }

--- a/internal/web/static/js/symbol-modal.js
+++ b/internal/web/static/js/symbol-modal.js
@@ -191,7 +191,9 @@ class SymbolModal {
             if (response.ok) {
                 return response.json();
             }
-            throw new Error('Failed to save symbol');
+            return response.text().then(text => {
+                throw new Error(text.trim() || 'Failed to save symbol');
+            });
         })
         .then(data => {
             console.log('Symbol saved successfully:', data);
@@ -201,11 +203,12 @@ class SymbolModal {
         })
         .catch(error => {
             console.error('Error saving symbol:', error);
+            const message = error.message || 'Failed to save symbol. Please try again.';
             // Show error modal if available, otherwise alert
             if (window.showErrorModal) {
-                window.showErrorModal('Failed to save symbol. Please try again.');
+                window.showErrorModal(message);
             } else {
-                alert('Failed to save symbol. Please try again.');
+                alert(message);
             }
         });
     }

--- a/internal/web/static/js/symbol-modal.js
+++ b/internal/web/static/js/symbol-modal.js
@@ -11,9 +11,10 @@ class SymbolModal {
         this.cancelModal = null;
         this.symbolForm = null;
         this.modalTitle = null;
+        this.marketInput = null;
         this.isEditMode = false;
         this.editingSymbol = null;
-        
+
         this.init();
     }
     
@@ -25,10 +26,29 @@ class SymbolModal {
         this.cancelModal = document.getElementById('cancelModal');
         this.symbolForm = document.getElementById('symbolForm');
         this.modalTitle = document.getElementById('modalTitle');
+        this.marketInput = document.getElementById('marketInput');
         
         if (!this.modal) {
             console.warn('Symbol modal not found on this page');
             return;
+        }
+
+        if (this.marketInput) {
+            fetch('/api/markets')
+                .then(response => response.json())
+                .then(markets => {
+                    this.marketInput.innerHTML = '<option value="">Select a market</option>';
+                    markets.forEach(market => {
+                        const option = document.createElement('option');
+                        option.value = market.id;
+                        option.textContent = market.display_name;
+                        this.marketInput.appendChild(option);
+                    });
+                })
+                .catch(error => {
+                    console.error('Failed to load markets:', error);
+                    this.marketInput.innerHTML = '<option value="">Markets unavailable</option>';
+                });
         }
         
         this.bindEvents();
@@ -81,8 +101,14 @@ class SymbolModal {
             const peRatioInput = document.getElementById('peRatioInput');
             
             if (symbolInput) {
-                symbolInput.value = symbolData.symbol;
+                const parts = symbolData.symbol.split(':');
+                symbolInput.value = parts.length === 2 ? parts[1] : symbolData.symbol;
                 symbolInput.disabled = true;
+            }
+            if (this.marketInput) {
+                const parts = symbolData.symbol.split(':');
+                this.marketInput.value = parts.length === 2 ? parts[0] : '';
+                this.marketInput.disabled = parts.length === 2;
             }
             if (priceInput) priceInput.value = symbolData.price || '';
             if (dividendInput) dividendInput.value = symbolData.dividend || '';
@@ -96,6 +122,7 @@ class SymbolModal {
             if (symbolInput) {
                 symbolInput.disabled = false;
             }
+			if (this.marketInput) this.marketInput.disabled = false;
             this.editingSymbol = null;
         }
         
@@ -121,32 +148,44 @@ class SymbolModal {
         const dividendInput = document.getElementById('dividendInput');
         const exDividendDateInput = document.getElementById('exDividendDateInput');
         const peRatioInput = document.getElementById('peRatioInput');
+		const market = this.marketInput?.value;
         
         if (!symbolInput) {
             console.error('Symbol input not found');
             return;
         }
         
+        if (!market) {
+            alert('Select a market');
+            return;
+        }
+
         const symbolData = {
-            symbol: symbolInput.value.toUpperCase(),
+            symbol: `${market}:${symbolInput.value.toUpperCase().trim()}`,
             price: parseFloat(priceInput?.value) || 0,
             dividend: parseFloat(dividendInput?.value) || 0,
             ex_dividend_date: exDividendDateInput?.value || null,
             pe_ratio: parseFloat(peRatioInput?.value) || null
         };
         
-        const url = `/api/symbols/${symbolData.symbol}`;
-        const method = 'PUT'; // Using PUT for both create and update
-        
-        fetch(url, {
-            method: method,
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
+        const isLegacyEdit = this.isEditMode && this.editingSymbol && !this.editingSymbol.includes(':');
+        const url = isLegacyEdit
+            ? `/api/symbols/${encodeURIComponent(this.editingSymbol)}/qualify`
+            : `/api/symbols/${encodeURIComponent(symbolData.symbol)}`;
+        const method = isLegacyEdit ? 'POST' : 'PUT';
+        const body = isLegacyEdit
+            ? { market: market }
+            : {
                 price: symbolData.price,
                 dividend: symbolData.dividend,
                 ex_dividend_date: symbolData.ex_dividend_date,
                 pe_ratio: symbolData.pe_ratio
-            })
+            };
+
+        fetch(url, {
+            method: method,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body)
         })
         .then(response => {
             if (response.ok) {

--- a/internal/web/symbol_handlers.go
+++ b/internal/web/symbol_handlers.go
@@ -1,8 +1,8 @@
 package web
 
 import (
-	"encoding/json"
 	"context"
+	"encoding/json"
 	"log"
 	"net/http"
 	"sort"
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 )
-
 
 // symbolHandler serves the symbol-specific analysis view
 func (s *Server) symbolHandler(w http.ResponseWriter, r *http.Request) {
@@ -483,9 +482,9 @@ func (s *Server) symbolUpdatePriceHandler(w http.ResponseWriter, r *http.Request
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Update symbol price using Polygon service
+	// Update symbol price using configured market data provider
 	err := s.providerService.UpdateSymbolPrice(ctx, symbol)
-	
+
 	response := map[string]interface{}{
 		"success": err == nil,
 		"symbol":  symbol,
@@ -520,7 +519,7 @@ func (s *Server) symbolFetchDividendsHandler(w http.ResponseWriter, r *http.Requ
 
 	// Fetch dividend data using Polygon service
 	dividends, err := s.providerService.FetchDividendHistory(ctx, symbol, 10)
-	
+
 	response := map[string]interface{}{
 		"success": err == nil,
 		"symbol":  symbol,

--- a/internal/web/symbol_handlers.go
+++ b/internal/web/symbol_handlers.go
@@ -511,13 +511,19 @@ func (s *Server) symbolUpdatePriceHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	instrument, err := markets.Parse(symbol)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	symbol = instrument.Key()
 	log.Printf("[SYMBOL API] Updating price for symbol: %s", symbol)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	// Update symbol price using configured market data provider
-	err := s.providerService.UpdateSymbolPrice(ctx, symbol)
+	err = s.providerService.UpdateSymbolPrice(ctx, symbol)
 
 	response := map[string]interface{}{
 		"success": err == nil,
@@ -545,6 +551,12 @@ func (s *Server) symbolFetchDividendsHandler(w http.ResponseWriter, r *http.Requ
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
+	instrument, err := markets.Parse(symbol)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	symbol = instrument.Key()
 	if !s.providerService.ActiveProfile().SupportsDividends {
 		http.Error(w, "The configured provider does not support dividend history", http.StatusConflict)
 		return

--- a/internal/web/symbol_handlers.go
+++ b/internal/web/symbol_handlers.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"sort"
+	"stonks/internal/markets"
 	"stonks/internal/models"
 	"strconv"
 	"strings"
@@ -216,6 +217,7 @@ func (s *Server) symbolHandler(w http.ResponseWriter, r *http.Request) {
 		OptionsList:       optionsList,
 		LongPositionsList: longPositionsList,
 		MonthlyResults:    monthlyResults,
+		SupportsDividends: s.providerService.ActiveProfile().SupportsDividends,
 		CurrentDB:         s.getCurrentDatabaseName(),
 		ActivePage:        "symbol",
 	}
@@ -323,6 +325,12 @@ func (s *Server) updateSymbolHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Symbol is required", http.StatusBadRequest)
 		return
 	}
+	instrument, err := markets.Parse(symbol)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	symbol = instrument.Key()
 
 	var updateReq SymbolUpdateRequest
 	if err := json.NewDecoder(r.Body).Decode(&updateReq); err != nil {
@@ -336,7 +344,7 @@ func (s *Server) updateSymbolHandler(w http.ResponseWriter, r *http.Request) {
 		// If symbol doesn't exist, create it
 		existingSymbol, err = s.symbolService.Create(symbol)
 		if err != nil {
-			http.Error(w, "Failed to create symbol", http.StatusInternalServerError)
+			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 	}
@@ -447,6 +455,11 @@ func (s *Server) symbolAPIHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if len(pathSegments) > 1 && pathSegments[1] == "qualify" {
+		s.symbolQualifyHandler(w, r, symbol)
+		return
+	}
+
 	// Handle different HTTP methods for symbol operations
 	switch r.Method {
 	case http.MethodPut:
@@ -456,6 +469,27 @@ func (s *Server) symbolAPIHandler(w http.ResponseWriter, r *http.Request) {
 	default:
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 	}
+}
+
+func (s *Server) symbolQualifyHandler(w http.ResponseWriter, r *http.Request, symbol string) {
+	if r.Method != http.MethodPost && r.Method != http.MethodPut {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var request struct {
+		Market string `json:"market"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		return
+	}
+	qualified, err := s.symbolService.QualifyLegacySymbol(symbol, request.Market)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(qualified)
 }
 
 // symbolDividendsHandler provides API data for symbol-specific dividends
@@ -505,10 +539,14 @@ func (s *Server) symbolUpdatePriceHandler(w http.ResponseWriter, r *http.Request
 	}
 }
 
-// symbolFetchDividendsHandler fetches dividend data for a symbol from Polygon.io
+// symbolFetchDividendsHandler fetches dividend data for a symbol from the configured provider.
 func (s *Server) symbolFetchDividendsHandler(w http.ResponseWriter, r *http.Request, symbol string) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !s.providerService.ActiveProfile().SupportsDividends {
+		http.Error(w, "The configured provider does not support dividend history", http.StatusConflict)
 		return
 	}
 

--- a/internal/web/symbol_handlers.go
+++ b/internal/web/symbol_handlers.go
@@ -484,7 +484,7 @@ func (s *Server) symbolUpdatePriceHandler(w http.ResponseWriter, r *http.Request
 	defer cancel()
 
 	// Update symbol price using Polygon service
-	err := s.polygonService.UpdateSymbolPrice(ctx, symbol)
+	err := s.providerService.UpdateSymbolPrice(ctx, symbol)
 	
 	response := map[string]interface{}{
 		"success": err == nil,
@@ -519,7 +519,7 @@ func (s *Server) symbolFetchDividendsHandler(w http.ResponseWriter, r *http.Requ
 	defer cancel()
 
 	// Fetch dividend data using Polygon service
-	dividends, err := s.polygonService.FetchDividendHistory(ctx, symbol, 10)
+	dividends, err := s.providerService.FetchDividendHistory(ctx, symbol, 10)
 	
 	response := map[string]interface{}{
 		"success": err == nil,

--- a/internal/web/templates/_navigation.html
+++ b/internal/web/templates/_navigation.html
@@ -97,7 +97,7 @@
                 </a>
                 <a href="/settings" class="admin-nav-item {{if eq .ActivePage "settings"}}active{{end}}">
                     <i class="fas fa-chart-line"></i>
-                    Polygon
+                    Market Data
                 </a>
             </div>
         </div>

--- a/internal/web/templates/_symbol_modal.html
+++ b/internal/web/templates/_symbol_modal.html
@@ -9,8 +9,15 @@
         </div>
         <form id="symbolForm">
             <div class="form-group">
-                <label for="symbolInput" class="form-label">Symbol *</label>
-                <input type="text" id="symbolInput" class="form-input" placeholder="e.g. AAPL, MSFT" required>
+                <label for="symbolInput" class="form-label">Ticker *</label>
+                <input type="text" id="symbolInput" class="form-input" placeholder="e.g. AAPL, PETR4" required>
+            </div>
+            <div class="form-group">
+                <label for="marketInput" class="form-label">Market *</label>
+                <select id="marketInput" class="form-input" required>
+                    <option value="">Loading supported markets…</option>
+                </select>
+                <div class="form-help">New symbols are stored as MARKET:TICKER.</div>
             </div>
             <div class="form-group">
                 <label for="priceInput" class="form-label">Current Price</label>

--- a/internal/web/templates/settings.html
+++ b/internal/web/templates/settings.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Polygon - Wheeler</title>
+    <title>{{.ProviderName}} Settings - Wheeler</title>
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
     <link rel="stylesheet" href="/static/css/styles.css">
@@ -15,26 +15,26 @@
         <!-- Main Content -->
         <div class="main-content">
             <div class="content-section">
-                <div class="section-title">Polygon</div>
-                <div class="section-subtitle">Configure your Polygon.io API key for live market data</div>
+                <div class="section-title">Market Data Provider</div>
+                <div class="section-subtitle">Manage your {{.ProviderName}} API key for live market data</div>
                 
                 <!-- API Key Configuration Form -->
                 <div class="settings-form-container">
                     <div class="settings-card">
                         <div class="settings-card-header">
                             <i class="fas fa-key"></i>
-                            <h3>Polygon.io API Configuration</h3>
+                            <h3>{{.ProviderName}} API Configuration</h3>
                         </div>
                         <div class="settings-card-body">
                             <form id="apiKeyForm">
                                 <div class="form-group">
                                     <label for="apiKeyInput" class="form-label">API Key</label>
-                                    <input type="password" id="apiKeyInput" class="form-input" 
-                                           placeholder="Enter your Polygon.io API key"
+                                     <input type="password" id="apiKeyInput" class="form-input" 
+                                         placeholder="Enter your {{.ProviderName}} API key"
                                            value="{{if .ApiKey}}{{.ApiKey}}{{end}}">
                                     <div class="form-help">
                                         <i class="fas fa-info-circle"></i>
-                                        Get your free API key from <a href="https://polygon.io" target="_blank" rel="noopener">Polygon.io</a>
+                                        Get your API key from your provider dashboard. Polygon users can visit <a href="https://polygon.io" target="_blank" rel="noopener">Polygon.io</a>
                                     </div>
                                 </div>
                                 <div class="form-group">
@@ -82,16 +82,16 @@
                     <div class="info-card">
                         <div class="info-header">
                             <i class="fas fa-lightbulb"></i>
-                            <h4>About Polygon.io API</h4>
+                            <h4>About {{.ProviderName}}</h4>
                         </div>
                         <div class="info-content">
-                            <p>The Polygon.io API provides real-time and historical market data for stocks, options, and other financial instruments.</p>
+                            <p>{{.ProviderName}} powers live price checks, symbol lookups, and dividend history inside Wheeler.</p>
                             <ul>
-                                <li><strong>Free Tier:</strong> 5 API calls per minute, delayed data</li>
-                                <li><strong>Starter Plan:</strong> 100 API calls per minute, real-time data</li>
-                                <li><strong>Developer Plan:</strong> 1000 API calls per minute, additional endpoints</li>
+                                <li><strong>Requests:</strong> Price updates, symbol insights, and dividend history jobs share the same API quota.</li>
+                                <li><strong>Rate Limits:</strong> Bulk actions pace themselves to respect your provider's published limits.</li>
+                                <li><strong>Default Provider:</strong> Wheeler ships with native Polygon.io support; additional providers can hook into the same workflow.</li>
                             </ul>
-                            <p>Your API key will be used to automatically update stock prices and fetch dividend information.</p>
+                            <p>Need an API key? Sign in to your provider dashboard{{if eq .ProviderName "Polygon.io"}} or <a href="https://polygon.io" target="_blank" rel="noopener">create one at Polygon.io</a>{{end}}.</p>
                         </div>
                     </div>
                 </div>
@@ -267,6 +267,7 @@
     </style>
 
     <script>
+        const providerName = '{{.ProviderName}}';
         // Get API key value from backend
         let currentApiKey = '{{if .ApiKey}}{{.ApiKey}}{{end}}';
         
@@ -335,7 +336,7 @@
                 },
                 body: JSON.stringify({
                     value: apiKey,
-                    description: 'API key for Polygon.io stock market data integration'
+                    description: 'API key for ' + providerName + ' market data integration'
                 })
             })
             .then(response => {
@@ -367,7 +368,7 @@
             const originalText = btn.innerHTML;
             btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Testing...';
             
-            fetch('/api/polygon/test', {
+            fetch('/api/provider/test', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -395,7 +396,7 @@
         document.getElementById('updatePricesBtn').addEventListener('click', function() {
             const btn = this;
             
-            if (!confirm('This will update prices for all symbols using your Polygon.io API quota. Continue?')) {
+            if (!confirm('This will update prices for all symbols using your data provider API quota. Continue?')) {
                 return;
             }
             
@@ -403,7 +404,7 @@
             const originalText = btn.innerHTML;
             btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Updating...';
             
-            fetch('/api/polygon/update-prices', {
+            fetch('/api/provider/update-prices', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',

--- a/internal/web/templates/settings.html
+++ b/internal/web/templates/settings.html
@@ -16,25 +16,40 @@
         <div class="main-content">
             <div class="content-section">
                 <div class="section-title">Market Data Provider</div>
-                <div class="section-subtitle">Manage your {{.ProviderName}} API key for live market data</div>
+                <div class="section-subtitle">Choose the source Wheeler uses for live market data in this database.</div>
                 
                 <!-- API Key Configuration Form -->
                 <div class="settings-form-container">
                     <div class="settings-card">
                         <div class="settings-card-header">
-                            <i class="fas fa-key"></i>
-                            <h3>{{.ProviderName}} API Configuration</h3>
+                            <i class="fas fa-chart-line"></i>
+                            <h3>Provider Configuration</h3>
                         </div>
                         <div class="settings-card-body">
-                            <form id="apiKeyForm">
+                            <form id="providerConfigForm">
                                 <div class="form-group">
+                                    <label for="providerTypeInput" class="form-label">Market data provider</label>
+                                    <select id="providerTypeInput" class="form-input">
+                                        {{range .ProviderProfiles}}
+                                        <option value="{{.ID}}" data-requires-api-key="{{.RequiresAPIKey}}" data-supports-dividends="{{.SupportsDividends}}" {{if eq .ID $.ActiveProvider}}selected{{end}}>{{.DisplayName}}</option>
+                                        {{end}}
+                                    </select>
+                                    <div class="form-help">The choice is saved only in the active Wheeler database.</div>
+                                </div>
+                                <div class="form-group">
+                                    <div id="apiKeyField">
                                     <label for="apiKeyInput" class="form-label">API Key</label>
                                      <input type="password" id="apiKeyInput" class="form-input" 
-                                         placeholder="Enter your {{.ProviderName}} API key"
+                                         placeholder="Enter your Polygon.io API key"
                                            value="{{if .ApiKey}}{{.ApiKey}}{{end}}">
                                     <div class="form-help">
                                         <i class="fas fa-info-circle"></i>
-                                        Get your API key from your provider dashboard. Polygon users can visit <a href="https://polygon.io" target="_blank" rel="noopener">Polygon.io</a>
+                                        Polygon requires an API key. <a href="https://polygon.io" target="_blank" rel="noopener">Create one at Polygon.io</a>.
+                                    </div>
+                                    </div>
+                                    <div id="noApiKeyField" class="form-help" style="display: none;">
+                                        <i class="fas fa-info-circle"></i>
+                                        This provider does not require an API key.
                                     </div>
                                 </div>
                                 <div class="form-group">
@@ -43,9 +58,9 @@
                                             <i class="fas fa-eye" id="eyeIcon"></i>
                                             <span id="toggleText">Show</span>
                                         </button>
-                                        <button type="submit" class="btn btn-primary" id="saveApiKeyBtn">
+                                        <button type="submit" class="btn btn-primary" id="saveProviderBtn">
                                             <i class="fas fa-save"></i>
-                                            Save API Key
+                                            Save Configuration
                                         </button>
                                     </div>
                                 </div>
@@ -58,7 +73,7 @@
                                     <span id="statusText">Not configured</span>
                                 </div>
                                 <div class="status-description" id="statusDescription">
-                                    Configure your API key to enable live market data updates
+                                    Loading provider configuration…
                                 </div>
                             </div>
                             
@@ -85,13 +100,13 @@
                             <h4>About {{.ProviderName}}</h4>
                         </div>
                         <div class="info-content">
-                            <p>{{.ProviderName}} powers live price checks, symbol lookups, and dividend history inside Wheeler.</p>
+                            <p id="providerDescription">{{.ProviderName}} powers live price checks and symbol lookups inside Wheeler.</p>
                             <ul>
-                                <li><strong>Requests:</strong> Price updates, symbol insights, and dividend history jobs share the same API quota.</li>
+                                <li><strong>Requests:</strong> Price updates and symbol insights use the selected provider.</li>
                                 <li><strong>Rate Limits:</strong> Bulk actions pace themselves to respect your provider's published limits.</li>
-                                <li><strong>Default Provider:</strong> Wheeler ships with native Polygon.io support; additional providers can hook into the same workflow.</li>
+                                <li id="dividendCapability"><strong>Dividend history:</strong> Loading capability…</li>
                             </ul>
-                            <p>Need an API key? Sign in to your provider dashboard{{if eq .ProviderName "Polygon.io"}} or <a href="https://polygon.io" target="_blank" rel="noopener">create one at Polygon.io</a>{{end}}.</p>
+                            <p>Changing provider does not modify existing prices or dividends stored in Wheeler.</p>
                         </div>
                     </div>
                 </div>
@@ -267,12 +282,30 @@
     </style>
 
     <script>
-        const providerName = '{{.ProviderName}}';
-        // Get API key value from backend
         let currentApiKey = '{{if .ApiKey}}{{.ApiKey}}{{end}}';
+        const providerTypeInput = document.getElementById('providerTypeInput');
+        const apiKeyField = document.getElementById('apiKeyField');
+        const noApiKeyField = document.getElementById('noApiKeyField');
+        const toggleVisibilityBtn = document.getElementById('toggleVisibilityBtn');
+
+        function selectedProvider() {
+            return providerTypeInput.options[providerTypeInput.selectedIndex];
+        }
+
+        function providerName() {
+            return selectedProvider().textContent;
+        }
+
+        function providerCapabilities() {
+            const option = selectedProvider();
+            return {
+                requiresApiKey: option.dataset.requiresApiKey === 'true',
+                supportsDividends: option.dataset.supportsDividends === 'true'
+            };
+        }
         
         // Toggle API key visibility
-        document.getElementById('toggleVisibilityBtn').addEventListener('click', function() {
+        toggleVisibilityBtn.addEventListener('click', function() {
             const input = document.getElementById('apiKeyInput');
             const eyeIcon = document.getElementById('eyeIcon');
             const toggleText = document.getElementById('toggleText');
@@ -288,8 +321,20 @@
             }
         });
 
-        // Update API status display
-        function updateApiStatus(hasKey, isValid = null) {
+        function updateProviderUI() {
+            const capabilities = providerCapabilities();
+            apiKeyField.style.display = capabilities.requiresApiKey ? 'block' : 'none';
+            noApiKeyField.style.display = capabilities.requiresApiKey ? 'none' : 'flex';
+            toggleVisibilityBtn.style.display = capabilities.requiresApiKey ? 'inline-flex' : 'none';
+            document.getElementById('providerDescription').textContent = `${providerName()} powers live price checks and symbol lookups inside Wheeler.`;
+            document.getElementById('dividendCapability').innerHTML = capabilities.supportsDividends
+                ? '<strong>Dividend history:</strong> supported by this provider.'
+                : '<strong>Dividend history:</strong> not available from Google Finance; Wheeler will not request it.';
+            updateApiStatus(capabilities);
+        }
+
+        // Update provider readiness display.
+        function updateApiStatus(capabilities) {
             const statusIndicator = document.querySelector('.status-indicator');
             const statusIcon = document.getElementById('statusIcon');
             const statusText = document.getElementById('statusText');
@@ -301,7 +346,13 @@
             apiStatus.classList.remove('configured', 'error', 'not-configured');
             statusIndicator.classList.remove('configured', 'error', 'not-configured');
             
-            if (!hasKey) {
+            if (!capabilities.requiresApiKey) {
+                apiStatus.classList.add('configured');
+                statusIndicator.classList.add('configured');
+                statusText.textContent = 'Ready';
+                statusDescription.textContent = 'No API key is required for this provider';
+                apiActions.style.display = 'flex';
+            } else if (!currentApiKey) {
                 apiStatus.classList.add('not-configured');
                 statusIndicator.classList.add('not-configured');
                 statusText.textContent = 'Not configured';
@@ -316,43 +367,43 @@
             }
         }
 
+        providerTypeInput.addEventListener('change', updateProviderUI);
+
         // Form submission
-        document.getElementById('apiKeyForm').addEventListener('submit', function(e) {
+        document.getElementById('providerConfigForm').addEventListener('submit', function(e) {
             e.preventDefault();
-            
+            const capabilities = providerCapabilities();
+            const providerType = providerTypeInput.value;
             const apiKey = document.getElementById('apiKeyInput').value.trim();
-            const saveBtn = document.getElementById('saveApiKeyBtn');
+            const saveBtn = document.getElementById('saveProviderBtn');
             
             // Disable button and show loading state
             saveBtn.disabled = true;
             const originalText = saveBtn.innerHTML;
             saveBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Saving...';
             
-            // Update API key via API
-            fetch('/api/settings/POLYGON_API_KEY', {
+            fetch('/api/provider/configuration', {
                 method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
+                headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
-                    value: apiKey,
-                    description: 'API key for ' + providerName + ' market data integration'
+                    provider_type: providerType,
+                    polygon_api_key: capabilities.requiresApiKey ? apiKey : ''
                 })
             })
             .then(response => {
                 if (!response.ok) {
-                    throw new Error('Failed to save API key');
+                    return response.text().then(message => { throw new Error(message || 'Failed to save provider configuration'); });
                 }
                 return response.json();
             })
-            .then(data => {
+            .then(() => {
                 currentApiKey = apiKey;
-                updateApiStatus(apiKey.length > 0);
-                showNotification('API key saved successfully!', 'success');
+                updateProviderUI();
+                showNotification('Provider configuration saved successfully!', 'success');
             })
             .catch(error => {
-                console.error('Error saving API key:', error);
-                showNotification('Error saving API key: ' + error.message, 'error');
+                console.error('Error saving provider configuration:', error);
+                showNotification('Error saving provider configuration: ' + error.message, 'error');
             })
             .finally(() => {
                 // Restore button state
@@ -432,7 +483,7 @@
 
         // Initialize status display
         document.addEventListener('DOMContentLoaded', function() {
-            updateApiStatus(currentApiKey.length > 0);
+            updateProviderUI();
         });
 
         function showNotification(message, type) {

--- a/internal/web/templates/settings.html
+++ b/internal/web/templates/settings.html
@@ -17,6 +17,19 @@
             <div class="content-section">
                 <div class="section-title">Market Data Provider</div>
                 <div class="section-subtitle">Choose the source Wheeler uses for live market data in this database.</div>
+
+                {{if .LegacySymbols}}
+                <div class="info-card" style="margin: 16px 0; border-left: 4px solid #f59e0b;">
+                    <div class="info-header">
+                        <i class="fas fa-exclamation-triangle"></i>
+                        <h4>Market selection required</h4>
+                    </div>
+                    <div class="info-content">
+                        <p>Provider updates require symbols in <code>MARKET:TICKER</code> form. Edit each legacy symbol below and select its market before requesting provider data.</p>
+                        <p>{{range $index, $symbol := .LegacySymbols}}{{if $index}}, {{end}}<code>{{$symbol}}</code>{{end}}</p>
+                    </div>
+                </div>
+                {{end}}
                 
                 <!-- API Key Configuration Form -->
                 <div class="settings-form-container">
@@ -283,6 +296,7 @@
 
     <script>
         let currentApiKey = '{{if .ApiKey}}{{.ApiKey}}{{end}}';
+        let savedProviderType = '{{.ActiveProvider}}';
         const providerTypeInput = document.getElementById('providerTypeInput');
         const apiKeyField = document.getElementById('apiKeyField');
         const noApiKeyField = document.getElementById('noApiKeyField');
@@ -346,7 +360,13 @@
             apiStatus.classList.remove('configured', 'error', 'not-configured');
             statusIndicator.classList.remove('configured', 'error', 'not-configured');
             
-            if (!capabilities.requiresApiKey) {
+            if (providerTypeInput.value !== savedProviderType) {
+                apiStatus.classList.add('not-configured');
+                statusIndicator.classList.add('not-configured');
+                statusText.textContent = 'Unsaved provider selection';
+                statusDescription.textContent = 'Save this provider configuration before testing or updating prices.';
+                apiActions.style.display = 'none';
+            } else if (!capabilities.requiresApiKey) {
                 apiStatus.classList.add('configured');
                 statusIndicator.classList.add('configured');
                 statusText.textContent = 'Ready';
@@ -396,8 +416,9 @@
                 }
                 return response.json();
             })
-            .then(() => {
+            .then(data => {
                 currentApiKey = apiKey;
+                savedProviderType = data.provider;
                 updateProviderUI();
                 showNotification('Provider configuration saved successfully!', 'success');
             })
@@ -447,7 +468,7 @@
         document.getElementById('updatePricesBtn').addEventListener('click', function() {
             const btn = this;
             
-            if (!confirm('This will update prices for all symbols using your data provider API quota. Continue?')) {
+            if (!confirm('This updates at most 20 symbols per request to respect provider rate limits. Run it again to process any remaining symbols. Continue?')) {
                 return;
             }
             
@@ -465,7 +486,11 @@
             .then(response => response.json())
             .then(data => {
                 if (data.success) {
-                    showNotification(`Price update completed! Updated: ${data.updated}, Failed: ${data.failed}`, 'success');
+                    let message = `Price update completed! Updated: ${data.updated}, Failed: ${data.failed}`;
+                    if (data.skipped > 0) {
+                        message += ` ${data.skipped} symbols remain; run Update All again to continue.`;
+                    }
+                    showNotification(message, 'success');
                 } else {
                     showNotification('Price update failed: ' + (data.message || 'Unknown error'), 'error');
                 }

--- a/internal/web/templates/symbol.html
+++ b/internal/web/templates/symbol.html
@@ -748,6 +748,7 @@
         const modalTitle = document.getElementById('modalTitle');
         const marketInput = document.getElementById('marketInput');
         let editingLegacySymbol = null;
+		let selectedMarket = '';
 
         fetch('/api/markets').then(response => response.json()).then(markets => {
             marketInput.innerHTML = '<option value="">Select a market</option>';
@@ -757,6 +758,9 @@
                 option.textContent = market.display_name;
                 marketInput.appendChild(option);
             });
+			if (selectedMarket) {
+				marketInput.value = selectedMarket;
+			}
         });
         
         // Open modal for editing current symbol
@@ -808,7 +812,8 @@
                 const parts = symbolData.symbol.split(':');
                 const isCanonical = parts.length === 2;
                 document.getElementById('symbolInput').value = isCanonical ? parts[1] : symbolData.symbol;
-                marketInput.value = isCanonical ? parts[0] : '';
+				selectedMarket = isCanonical ? parts[0] : '';
+                marketInput.value = selectedMarket;
                 document.getElementById('priceInput').value = symbolData.price || '';
                 document.getElementById('dividendInput').value = symbolData.dividend || '';
                 document.getElementById('exDividendDateInput').value = symbolData.exDividendDate || '';
@@ -823,6 +828,7 @@
                 symbolForm.reset();
                 document.getElementById('symbolInput').disabled = false;
 				marketInput.disabled = false;
+				selectedMarket = '';
 				editingLegacySymbol = null;
             }
             

--- a/internal/web/templates/symbol.html
+++ b/internal/web/templates/symbol.html
@@ -746,6 +746,18 @@
         const cancelModal = document.getElementById('cancelModal');
         const symbolForm = document.getElementById('symbolForm');
         const modalTitle = document.getElementById('modalTitle');
+        const marketInput = document.getElementById('marketInput');
+        let editingLegacySymbol = null;
+
+        fetch('/api/markets').then(response => response.json()).then(markets => {
+            marketInput.innerHTML = '<option value="">Select a market</option>';
+            markets.forEach(market => {
+                const option = document.createElement('option');
+                option.value = market.id;
+                option.textContent = market.display_name;
+                marketInput.appendChild(option);
+            });
+        });
         
         // Open modal for editing current symbol
         console.log('About to set up editSymbolBtn listener...');
@@ -793,15 +805,25 @@
             modalTitle.textContent = editMode ? 'Edit Symbol' : 'New Symbol';
             
             if (editMode && symbolData) {
-                document.getElementById('symbolInput').value = symbolData.symbol;
+                const parts = symbolData.symbol.split(':');
+                const isCanonical = parts.length === 2;
+                document.getElementById('symbolInput').value = isCanonical ? parts[1] : symbolData.symbol;
+                marketInput.value = isCanonical ? parts[0] : '';
                 document.getElementById('priceInput').value = symbolData.price || '';
                 document.getElementById('dividendInput').value = symbolData.dividend || '';
                 document.getElementById('exDividendDateInput').value = symbolData.exDividendDate || '';
                 document.getElementById('peRatioInput').value = symbolData.pe_ratio || '';
                 document.getElementById('symbolInput').disabled = true;
+				marketInput.disabled = isCanonical;
+				editingLegacySymbol = isCanonical ? null : symbolData.symbol;
+				if (!isCanonical) {
+					modalTitle.textContent = 'Select market for legacy symbol';
+				}
             } else {
                 symbolForm.reset();
                 document.getElementById('symbolInput').disabled = false;
+				marketInput.disabled = false;
+				editingLegacySymbol = null;
             }
             
             modal.style.display = 'block';
@@ -817,20 +839,29 @@
             e.preventDefault();
             
             const exDivDateValue = document.getElementById('exDividendDateInput').value;
+            const ticker = document.getElementById('symbolInput').value.toUpperCase().trim();
+            const market = marketInput.value;
             const symbolData = {
-                symbol: document.getElementById('symbolInput').value.toUpperCase(),
+                symbol: `${market}:${ticker}`,
                 price: parseFloat(document.getElementById('priceInput').value) || 0,
                 dividend: parseFloat(document.getElementById('dividendInput').value) || 0,
                 ex_dividend_date: exDivDateValue || null,
                 pe_ratio: parseFloat(document.getElementById('peRatioInput').value) || null
             };
             
-            const url = `/api/symbols/${symbolData.symbol}`;
+            const url = editingLegacySymbol
+                ? `/api/symbols/${encodeURIComponent(editingLegacySymbol)}/qualify`
+                : `/api/symbols/${encodeURIComponent(symbolData.symbol)}`;
+
+            if (!market) {
+                alert('Select a market');
+                return;
+            }
             
             fetch(url, {
                 method: 'PUT',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
+                body: editingLegacySymbol ? JSON.stringify({ market }) : JSON.stringify({
                     price: symbolData.price,
                     dividend: symbolData.dividend,
                     ex_dividend_date: symbolData.ex_dividend_date,
@@ -1578,6 +1609,11 @@
         }
 
         function fetchSymbolDividends(symbol) {
+            const supportsDividends = {{.SupportsDividends}};
+            if (!supportsDividends) {
+                alert('The configured market data provider does not support dividend history.');
+                return;
+            }
             const fetchBtn = document.getElementById('fetchDividendsBtn');
             const originalText = fetchBtn.innerHTML;
             

--- a/internal/web/types.go
+++ b/internal/web/types.go
@@ -80,7 +80,7 @@ type CSVTreasuryRecord struct {
 // DashboardData holds data for the dashboard template
 type DashboardData struct {
 	Symbols         []string        `json:"symbols"`
-	AllSymbols      []string        `json:"allSymbols"`     // For navigation compatibility
+	AllSymbols      []string        `json:"allSymbols"` // For navigation compatibility
 	SymbolSummaries []SymbolSummary `json:"symbolSummaries"`
 	LongByTicker    []ChartData     `json:"longByTicker"`
 	PutsByTicker    []ChartData     `json:"putsByTicker"`
@@ -128,25 +128,25 @@ type DashboardTotals struct {
 
 // MonthlyData holds data for the monthly template
 type MonthlyData struct {
-	Symbols                  []string                      `json:"symbols"`
-	AllSymbols               []string                      `json:"allSymbols"` // For navigation compatibility
-	PutsData                 MonthlyOptionData             `json:"putsData"`
-	CallsData                MonthlyOptionData             `json:"callsData"`
-	CapGainsData             MonthlyFinancialData          `json:"capGainsData"`
-	DividendsData            MonthlyFinancialData          `json:"dividendsData"`
-	TableData                []MonthlyTableRow             `json:"tableData"`
-	TableYearMonths          []string                      `json:"tableYearMonths"` // Sorted yyyy-mm columns for table
-	TableMonthLabels         []string                      `json:"tableMonthLabels"` // Formatted labels ("2025 Jan", etc.)
-	TableTotalsByMonth       map[string]float64            `json:"tableTotalsByMonth"` // yyyy-mm -> total for table
-	TotalsByMonth            []MonthlyTotal                `json:"totalsByMonth"` // Jan-Dec for charts
-	MonthlyPremiumsBySymbol  []MonthlyPremiumsBySymbol     `json:"monthlyPremiumsBySymbol"`
-	OptionsIndex             map[string]interface{}        `json:"options_index"`
-	OptionsIndexJSON         template.JS                   `json:"-"` // JSON-encoded for template
-	GrandTotal               float64                       `json:"grandTotal"`
-	CurrentDB                string                        `json:"currentDB"`
-	ActivePage               string                        `json:"activePage"`
-	SelectedFromDate         string                        `json:"selectedFromDate"`
-	SelectedToDate           string                        `json:"selectedToDate"`
+	Symbols                 []string                  `json:"symbols"`
+	AllSymbols              []string                  `json:"allSymbols"` // For navigation compatibility
+	PutsData                MonthlyOptionData         `json:"putsData"`
+	CallsData               MonthlyOptionData         `json:"callsData"`
+	CapGainsData            MonthlyFinancialData      `json:"capGainsData"`
+	DividendsData           MonthlyFinancialData      `json:"dividendsData"`
+	TableData               []MonthlyTableRow         `json:"tableData"`
+	TableYearMonths         []string                  `json:"tableYearMonths"`    // Sorted yyyy-mm columns for table
+	TableMonthLabels        []string                  `json:"tableMonthLabels"`   // Formatted labels ("2025 Jan", etc.)
+	TableTotalsByMonth      map[string]float64        `json:"tableTotalsByMonth"` // yyyy-mm -> total for table
+	TotalsByMonth           []MonthlyTotal            `json:"totalsByMonth"`      // Jan-Dec for charts
+	MonthlyPremiumsBySymbol []MonthlyPremiumsBySymbol `json:"monthlyPremiumsBySymbol"`
+	OptionsIndex            map[string]interface{}    `json:"options_index"`
+	OptionsIndexJSON        template.JS               `json:"-"` // JSON-encoded for template
+	GrandTotal              float64                   `json:"grandTotal"`
+	CurrentDB               string                    `json:"currentDB"`
+	ActivePage              string                    `json:"activePage"`
+	SelectedFromDate        string                    `json:"selectedFromDate"`
+	SelectedToDate          string                    `json:"selectedToDate"`
 }
 
 type MonthlyOptionData struct {
@@ -182,7 +182,7 @@ type MonthlyTotal struct {
 
 // MonthlyPremiumsBySymbol holds data for stacked bar chart showing monthly premiums by symbol
 type MonthlyPremiumsBySymbol struct {
-	Month   string             `json:"month"`
+	Month   string              `json:"month"`
 	Symbols []SymbolPremiumData `json:"symbols"`
 }
 
@@ -196,7 +196,7 @@ type TreasuriesData struct {
 	Symbols    []string           `json:"symbols"`
 	AllSymbols []string           `json:"allSymbols"` // For navigation compatibility
 	Treasuries []*models.Treasury `json:"treasuries"`
-	Options    []*models.Option   `json:"options"`    // For put exposure chart
+	Options    []*models.Option   `json:"options"` // For put exposure chart
 	Summary    TreasuriesSummary  `json:"summary"`
 	CurrentDB  string             `json:"currentDB"`
 	ActivePage string             `json:"activePage"`
@@ -224,21 +224,21 @@ type OptionsData struct {
 
 // AllOptionsData holds data for the all options template
 type AllOptionsData struct {
-	Symbols       []string                    `json:"symbols"`
-	AllSymbols    []string                    `json:"allSymbols"` // For navigation compatibility
-	OptionsIndex  map[string]interface{}      `json:"options_index"`
-	CurrentDB     string                      `json:"currentDB"`
-	ActivePage    string                      `json:"activePage"`
+	Symbols      []string               `json:"symbols"`
+	AllSymbols   []string               `json:"allSymbols"` // For navigation compatibility
+	OptionsIndex map[string]interface{} `json:"options_index"`
+	CurrentDB    string                 `json:"currentDB"`
+	ActivePage   string                 `json:"activePage"`
 }
 
 // AllOptionsDataWithJSON includes JSON-encoded version for JavaScript
 type AllOptionsDataWithJSON struct {
-	Symbols          []string                    `json:"symbols"`
-	AllSymbols       []string                    `json:"allSymbols"` // For navigation compatibility
-	OptionsIndex     map[string]interface{}      `json:"options_index"`
-	OptionsIndexJSON template.JS                 `json:"-"` // JSON-encoded for template
-	CurrentDB        string                      `json:"currentDB"`
-	ActivePage       string                      `json:"activePage"`
+	Symbols          []string               `json:"symbols"`
+	AllSymbols       []string               `json:"allSymbols"` // For navigation compatibility
+	OptionsIndex     map[string]interface{} `json:"options_index"`
+	OptionsIndexJSON template.JS            `json:"-"` // JSON-encoded for template
+	CurrentDB        string                 `json:"currentDB"`
+	ActivePage       string                 `json:"activePage"`
 }
 
 // SymbolMonthlyResult represents monthly results for a specific symbol
@@ -275,6 +275,7 @@ type SymbolData struct {
 	OptionsList       []*models.Option       `json:"optionsList"`
 	LongPositionsList []*models.LongPosition `json:"longPositionsList"`
 	MonthlyResults    []SymbolMonthlyResult  `json:"monthlyResults"`
+	SupportsDividends bool                   `json:"supportsDividends"`
 	CurrentDB         string                 `json:"currentDB"`
 	ActivePage        string                 `json:"activePage"`
 }
@@ -302,7 +303,7 @@ type DividendRequest struct {
 }
 
 type LongPositionRequest struct {
-	ID        *int     `json:"id,omitempty"`        // For updates
+	ID        *int     `json:"id,omitempty"` // For updates
 	Symbol    string   `json:"symbol"`
 	Shares    int      `json:"shares"`
 	BuyPrice  float64  `json:"buy_price"`
@@ -313,16 +314,16 @@ type LongPositionRequest struct {
 }
 
 type AllocationData struct {
-	LongByTicker        []ChartData `json:"longByTicker"`
-	PutsByTicker        []ChartData `json:"putsByTicker"`
-	CallsToLongs        []ChartData `json:"callsToLongs"`
-	TotalAllocation     []ChartData `json:"totalAllocation"`
-	PutROI              float64     `json:"putROI"`
-	LongROI             float64     `json:"longROI"`
-	TotalPutPremiums    float64     `json:"totalPutPremiums"`
-	TotalCallPremiums   float64     `json:"totalCallPremiums"`
-	TotalCallCovered    float64     `json:"totalCallCovered"`
-	TotalOptionable     float64     `json:"totalOptionable"`
+	LongByTicker      []ChartData `json:"longByTicker"`
+	PutsByTicker      []ChartData `json:"putsByTicker"`
+	CallsToLongs      []ChartData `json:"callsToLongs"`
+	TotalAllocation   []ChartData `json:"totalAllocation"`
+	PutROI            float64     `json:"putROI"`
+	LongROI           float64     `json:"longROI"`
+	TotalPutPremiums  float64     `json:"totalPutPremiums"`
+	TotalCallPremiums float64     `json:"totalCallPremiums"`
+	TotalCallCovered  float64     `json:"totalCallCovered"`
+	TotalOptionable   float64     `json:"totalOptionable"`
 }
 
 type ChartPoint struct {
@@ -341,7 +342,7 @@ type OptionScatterPoint struct {
 	ExpirationDate string  `json:"expirationDate"` // For JS Date parsing
 	Profit         float64 `json:"profit"`         // Y-axis value
 	Symbol         string  `json:"symbol"`         // For tooltip
-	Type           string  `json:"type"`           // "Put" or "Call"  
+	Type           string  `json:"type"`           // "Put" or "Call"
 	Strike         float64 `json:"strike"`         // Strike price
 	Contracts      int     `json:"contracts"`      // Quantity
 	DTE            int     `json:"dte"`            // Days to expiration
@@ -384,12 +385,12 @@ type TutorialIncomeData struct {
 
 // MetricsData holds data for the metrics template
 type MetricsData struct {
-	PageTitle  string            `json:"pageTitle"`
-	Symbols    []string          `json:"symbols"`
-	AllSymbols []string          `json:"allSymbols"` // For navigation compatibility
-	Metrics    []*models.Metric  `json:"metrics"`
-	CurrentDB  string            `json:"currentDB"`
-	ActivePage string            `json:"activePage"`
+	PageTitle  string           `json:"pageTitle"`
+	Symbols    []string         `json:"symbols"`
+	AllSymbols []string         `json:"allSymbols"` // For navigation compatibility
+	Metrics    []*models.Metric `json:"metrics"`
+	CurrentDB  string           `json:"currentDB"`
+	ActivePage string           `json:"activePage"`
 }
 
 // HelpData holds data for the help template
@@ -425,36 +426,36 @@ type ZenData struct {
 
 // DividendSymbolData holds dividend information for symbols on the dividends page
 type DividendSymbolData struct {
-	Symbol            string     `json:"symbol"`
-	Price             float64    `json:"price"`
-	Dividend          float64    `json:"dividend"`          // Quarterly dividend
-	AnnualDividend    float64    `json:"annualDividend"`    // Quarterly x 4
-	YieldPercent      float64    `json:"yieldPercent"`      // Based on annual dividend
-	ExDividendDate    *time.Time `json:"exDividendDate"`
-	DividendCount     int        `json:"dividendCount"`
-	Shares            int        `json:"shares"`            // Total number of shares held
-	TotalAnnualIncome float64    `json:"totalAnnualIncome"` // Shares x annual dividend
-	Positions         []*models.LongPosition `json:"positions"` // Individual positions
-	DividendPayments  []*models.Dividend     `json:"dividendPayments"` // Historical dividend payments
+	Symbol            string                 `json:"symbol"`
+	Price             float64                `json:"price"`
+	Dividend          float64                `json:"dividend"`       // Quarterly dividend
+	AnnualDividend    float64                `json:"annualDividend"` // Quarterly x 4
+	YieldPercent      float64                `json:"yieldPercent"`   // Based on annual dividend
+	ExDividendDate    *time.Time             `json:"exDividendDate"`
+	DividendCount     int                    `json:"dividendCount"`
+	Shares            int                    `json:"shares"`            // Total number of shares held
+	TotalAnnualIncome float64                `json:"totalAnnualIncome"` // Shares x annual dividend
+	Positions         []*models.LongPosition `json:"positions"`         // Individual positions
+	DividendPayments  []*models.Dividend     `json:"dividendPayments"`  // Historical dividend payments
 }
 
 // DividendsPageData holds all data for the enhanced dividends page
 type DividendsPageData struct {
 	PageData
-	DividendSymbols        []DividendSymbolData       `json:"dividendSymbols"`
-	IncomeBySymbol         []ChartData                `json:"incomeBySymbol"`         // Pie chart data
-	DividendsOverTime      []MonthlyChartData         `json:"dividendsOverTime"`      // Historical payments (deprecated)
+	DividendSymbols         []DividendSymbolData       `json:"dividendSymbols"`
+	IncomeBySymbol          []ChartData                `json:"incomeBySymbol"`          // Pie chart data
+	DividendsOverTime       []MonthlyChartData         `json:"dividendsOverTime"`       // Historical payments (deprecated)
 	DividendsStackedByMonth []DividendStackedMonthData `json:"dividendsStackedByMonth"` // Stacked bar chart data
-	UpcomingExDivDates     []UpcomingDividendDate     `json:"upcomingExDivDates"`     // Calendar data
-	TotalAnnualIncome      float64                    `json:"totalAnnualIncome"`
-	TotalDividendsPaid     float64                    `json:"totalDividendsPaid"`
-	AverageYield           float64                    `json:"averageYield"`
+	UpcomingExDivDates      []UpcomingDividendDate     `json:"upcomingExDivDates"`      // Calendar data
+	TotalAnnualIncome       float64                    `json:"totalAnnualIncome"`
+	TotalDividendsPaid      float64                    `json:"totalDividendsPaid"`
+	AverageYield            float64                    `json:"averageYield"`
 }
 
 // DividendStackedMonthData holds stacked bar chart data for dividends by month and symbol
 type DividendStackedMonthData struct {
-	Months  []string                   `json:"months"`  // Sorted month labels
-	Symbols []string                   `json:"symbols"` // Sorted symbol list
+	Months  []string                      `json:"months"`  // Sorted month labels
+	Symbols []string                      `json:"symbols"` // Sorted symbol list
 	Data    map[string]map[string]float64 `json:"data"`    // data[symbol][month] = amount
 }
 

--- a/model.md
+++ b/model.md
@@ -182,6 +182,8 @@ Represents application configuration settings stored as name-value pairs for dyn
 
 **Common Settings:**
 - **POLYGON_API_KEY**: API key for Polygon.io stock market data integration
+- **DATA_PROVIDER_TYPE**: Active provider: `polygon`, `google_finance`, or `yfinance` (legacy aliases are normalized)
+- **GOOGLE_FINANCE_EXCHANGE**: Default exchange used for Google Finance symbols, such as `NASDAQ`
 - **AUTO_UPDATE_INTERVAL**: Minutes between automatic price updates
 - **DEFAULT_CURRENCY**: Base currency for portfolio calculations
 - **ENABLE_NOTIFICATIONS**: Enable/disable system notifications
@@ -292,4 +294,3 @@ Multiplier Gradient:
 - Fair (≥0.5): #d8cf4c (bright yellow)
 - Poor (≥0.0): #e49a58 (bright orange)
 - Losing (<0.0): #f16565 (bright red)
-

--- a/model.md
+++ b/model.md
@@ -183,7 +183,7 @@ Represents application configuration settings stored as name-value pairs for dyn
 **Common Settings:**
 - **POLYGON_API_KEY**: API key for Polygon.io stock market data integration
 - **DATA_PROVIDER_TYPE**: Active provider: `polygon`, `google_finance`, or `yfinance` (legacy aliases are normalized)
-- **GOOGLE_FINANCE_EXCHANGE**: Default exchange used for Google Finance symbols, such as `NASDAQ`
+- **GOOGLE_FINANCE_EXCHANGE**: Legacy fallback exchange used when qualifying historical bare tickers; not used for new canonical symbols
 - **AUTO_UPDATE_INTERVAL**: Minutes between automatic price updates
 - **DEFAULT_CURRENCY**: Base currency for portfolio calculations
 - **ENABLE_NOTIFICATIONS**: Enable/disable system notifications

--- a/test/chart_handlers_test.go
+++ b/test/chart_handlers_test.go
@@ -117,7 +117,7 @@ func TestAllocationDataHandler(t *testing.T) {
 		t.Error("Expected non-negative call premiums")
 	}
 
-	t.Logf("✅ AllocationData test passed - found %d long positions, %d put exposures", 
+	t.Logf("✅ AllocationData test passed - found %d long positions, %d put exposures",
 		len(allocationData.LongByTicker), len(allocationData.PutsByTicker))
 }
 
@@ -340,7 +340,7 @@ func TestTutorialChartDataStructure(t *testing.T) {
 	for _, income := range unmarshalled.IncomeBreakdown {
 		totalPercentage += income.Percentage
 		totalAmount += income.Amount
-		
+
 		// Validate required fields
 		if income.Category == "" {
 			t.Error("Income category should not be empty")
@@ -374,16 +374,14 @@ func TestTutorialChartDataStructure(t *testing.T) {
 	expectedColors := []string{"#27ae60", "#3498db", "#9966FF", "#FFCE56"}
 	for i, income := range unmarshalled.IncomeBreakdown {
 		if income.Color != expectedColors[i] {
-			t.Errorf("Expected color %s for category %s, got %s", 
+			t.Errorf("Expected color %s for category %s, got %s",
 				expectedColors[i], income.Category, income.Color)
 		}
 	}
 
-	t.Logf("✅ TutorialChartData struct validation passed - Total: $%.2f, ROI: %.1f%%", 
+	t.Logf("✅ TutorialChartData struct validation passed - Total: $%.2f, ROI: %.1f%%",
 		unmarshalled.TotalReturn, unmarshalled.AnnualizedROI)
 }
-
-
 
 // Helper function to create deterministic test data for charts
 func createDeterministicChartData(t *testing.T, db *database.DB) {
@@ -393,7 +391,7 @@ func createDeterministicChartData(t *testing.T, db *database.DB) {
 	treasuryService := models.NewTreasuryService(db.DB)
 
 	// Create symbols
-	symbols := []string{"AAPL", "TSLA", "NVDA"}
+	symbols := []string{"NASDAQ:AAPL", "NASDAQ:TSLA", "NASDAQ:NVDA"}
 	for _, symbol := range symbols {
 		if _, err := symbolService.Create(symbol); err != nil {
 			t.Fatalf("Failed to create symbol %s: %v", symbol, err)
@@ -401,39 +399,39 @@ func createDeterministicChartData(t *testing.T, db *database.DB) {
 	}
 
 	// Update symbol prices (deterministic)
-	if _, err := symbolService.Update("AAPL", 150.0, 0, nil, nil); err != nil {
+	if _, err := symbolService.Update("NASDAQ:AAPL", 150.0, 0, nil, nil); err != nil {
 		t.Fatalf("Failed to update AAPL price: %v", err)
 	}
-	if _, err := symbolService.Update("TSLA", 200.0, 0, nil, nil); err != nil {
+	if _, err := symbolService.Update("NASDAQ:TSLA", 200.0, 0, nil, nil); err != nil {
 		t.Fatalf("Failed to update TSLA price: %v", err)
 	}
-	if _, err := symbolService.Update("NVDA", 400.0, 0, nil, nil); err != nil {
+	if _, err := symbolService.Update("NASDAQ:NVDA", 400.0, 0, nil, nil); err != nil {
 		t.Fatalf("Failed to update NVDA price: %v", err)
 	}
 
 	// Create long positions (deterministic amounts)
 	baseDate := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
-	
+
 	// AAPL: 100 shares at $150 = $15,000 value
-	if _, err := longPositionService.Create("AAPL", baseDate, 100, 150.0); err != nil {
+	if _, err := longPositionService.Create("NASDAQ:AAPL", baseDate, 100, 150.0); err != nil {
 		t.Fatalf("Failed to create AAPL long position: %v", err)
 	}
-	
-	// TSLA: 100 shares at $200 = $20,000 value  
-	if _, err := longPositionService.Create("TSLA", baseDate, 100, 200.0); err != nil {
+
+	// TSLA: 100 shares at $200 = $20,000 value
+	if _, err := longPositionService.Create("NASDAQ:TSLA", baseDate, 100, 200.0); err != nil {
 		t.Fatalf("Failed to create TSLA long position: %v", err)
 	}
 
 	// Create open put options (deterministic exposure)
 	expirationDate := time.Date(2024, 12, 20, 0, 0, 0, 0, time.UTC)
-	
+
 	// AAPL Put: 2 contracts at $145 strike = $29,000 exposure
-	if _, err := optionService.Create("AAPL", "Put", baseDate, 145.0, expirationDate, 5.50, 2); err != nil {
+	if _, err := optionService.Create("NASDAQ:AAPL", "Put", baseDate, 145.0, expirationDate, 5.50, 2); err != nil {
 		t.Fatalf("Failed to create AAPL put: %v", err)
 	}
-	
+
 	// TSLA Put: 1 contract at $190 strike = $19,000 exposure
-	if _, err := optionService.Create("TSLA", "Put", baseDate, 190.0, expirationDate, 7.25, 1); err != nil {
+	if _, err := optionService.Create("NASDAQ:TSLA", "Put", baseDate, 190.0, expirationDate, 7.25, 1); err != nil {
 		t.Fatalf("Failed to create TSLA put: %v", err)
 	}
 
@@ -441,7 +439,7 @@ func createDeterministicChartData(t *testing.T, db *database.DB) {
 	// $50,000 treasury at 4.5% yield
 	treasuryDate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	maturityDate := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
-	
+
 	if _, err := treasuryService.Create("TEST-TREASURY-001", treasuryDate, maturityDate, 50000.0, 4.5, 50000.0); err != nil {
 		t.Fatalf("Failed to create treasury: %v", err)
 	}
@@ -454,10 +452,10 @@ func createDeterministicMetricsData(t *testing.T, db *database.DB) {
 	// Create metrics service
 	// Note: This assumes metrics service exists - may need to create it
 	// For now, we'll insert directly into the metrics table
-	
+
 	// Create 30 days of metrics data (deterministic values)
 	baseDate := time.Date(2024, 11, 1, 0, 0, 0, 0, time.UTC)
-	
+
 	metricsData := []struct {
 		metricType string
 		baseValue  float64
@@ -475,15 +473,15 @@ func createDeterministicMetricsData(t *testing.T, db *database.DB) {
 	// Insert deterministic metrics for 30 days
 	for day := 0; day < 30; day++ {
 		currentDate := baseDate.AddDate(0, 0, day)
-		
+
 		for _, metric := range metricsData {
 			// Create deterministic but varying values
 			value := metric.baseValue + (metric.increment * float64(day))
-			
+
 			// Add some deterministic variation (sine wave pattern)
 			variation := value * 0.05 * (0.5 + 0.5*float64(day%7)/7.0)
 			finalValue := value + variation
-			
+
 			// Insert directly into database (this assumes metrics table structure)
 			query := `INSERT INTO metrics (created, type, value) VALUES (?, ?, ?)`
 			if _, err := db.DB.Exec(query, currentDate.Format("2006-01-02 15:04:05"), metric.metricType, finalValue); err != nil {
@@ -500,9 +498,9 @@ func createTestServer(db *database.DB) http.Handler {
 	// This would create a test server with the database
 	// For now, return a basic handler - this needs to be implemented
 	// based on the actual web server structure
-	
+
 	mux := http.NewServeMux()
-	
+
 	// Add minimal handler for testing
 	mux.HandleFunc("/api/allocation-data", func(w http.ResponseWriter, r *http.Request) {
 		// Return test data
@@ -523,11 +521,11 @@ func createTestServer(db *database.DB) http.Handler {
 			TotalPutPremiums:  1275.0,
 			TotalCallPremiums: 850.0,
 		}
-		
+
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(testData)
 	})
-	
+
 	mux.HandleFunc("/api/metrics/chart-data", func(w http.ResponseWriter, r *http.Request) {
 		// Return test metrics data
 		testData := map[string][]web.ChartPoint{
@@ -567,10 +565,10 @@ func createTestServer(db *database.DB) http.Handler {
 				{Date: "2024-11-03", Value: 50200.0},
 			},
 		}
-		
+
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(testData)
 	})
-	
+
 	return mux
 }

--- a/test/comprehensive_charts_test.go
+++ b/test/comprehensive_charts_test.go
@@ -235,7 +235,7 @@ func createComprehensiveTestData(t *testing.T, db *database.DB) {
 	treasuryService := models.NewTreasuryService(db.DB)
 
 	// Create multiple symbols
-	symbols := []string{"AAPL", "TSLA", "NVDA", "MSFT", "GOOGL"}
+	symbols := []string{"NASDAQ:AAPL", "NASDAQ:TSLA", "NASDAQ:NVDA", "NASDAQ:MSFT", "NASDAQ:GOOGL"}
 	prices := []float64{150.0, 200.0, 400.0, 350.0, 2500.0}
 
 	for i, symbol := range symbols {
@@ -323,7 +323,7 @@ func createLargeTestData(t *testing.T, db *database.DB) {
 
 	// Create many symbols
 	for i := 0; i < 50; i++ {
-		symbol := fmt.Sprintf("SYMBOL%03d", i+1)
+		symbol := fmt.Sprintf("NASDAQ:SYMBOL%03d", i+1)
 		if _, err := symbolService.Create(symbol); err != nil {
 			t.Fatalf("Failed to create symbol %s: %v", symbol, err)
 		}

--- a/test/comprehensive_charts_test.go
+++ b/test/comprehensive_charts_test.go
@@ -337,7 +337,7 @@ func createLargeTestData(t *testing.T, db *database.DB) {
 
 	for month := 0; month < 24; month++ { // 24 months of data
 		for i := 0; i < 10; i++ { // 10 options per month
-			symbol := fmt.Sprintf("SYMBOL%03d", (i%50)+1)
+			symbol := fmt.Sprintf("NASDAQ:SYMBOL%03d", (i%50)+1)
 			monthDate := baseDate.AddDate(0, month, 0)
 			openDate := monthDate.AddDate(0, 0, -30)
 			_ = monthDate.AddDate(0, 0, -5) // closeDate

--- a/test/monthly_handlers_test.go
+++ b/test/monthly_handlers_test.go
@@ -430,7 +430,7 @@ func createDeterministicMonthlyData(t *testing.T, db *database.DB) {
 		premium := 5.50 + float64(month)*0.25 // Increasing premium
 		_ = 3.25 + float64(month)*0.15        // exitPrice - Increasing exit price
 
-		option, err := optionService.Create("AAPL", "Put", openDate, 145.0, expirationDate, premium, 2)
+		option, err := optionService.Create("NASDAQ:AAPL", "Put", openDate, 145.0, expirationDate, premium, 2)
 		if err != nil {
 			t.Fatalf("Failed to create AAPL put for month %d: %v", month, err)
 		}
@@ -440,7 +440,7 @@ func createDeterministicMonthlyData(t *testing.T, db *database.DB) {
 		callPremium := 8.75 + float64(month)*0.50
 		_ = 4.25 + float64(month)*0.25 // callExitPrice
 
-		callOption, err := optionService.Create("TSLA", "Call", openDate, 200.0, expirationDate, callPremium, 1)
+		callOption, err := optionService.Create("NASDAQ:TSLA", "Call", openDate, 200.0, expirationDate, callPremium, 1)
 		if err != nil {
 			t.Fatalf("Failed to create TSLA call for month %d: %v", month, err)
 		}
@@ -453,7 +453,7 @@ func createDeterministicMonthlyData(t *testing.T, db *database.DB) {
 			sellPrice := buyPrice + 10.0 + float64(month)*2.0
 			sellDate := monthDate.AddDate(0, 0, 15)
 
-			_, err := longPositionService.Create("NVDA", openDate, shares, buyPrice)
+			_, err := longPositionService.Create("NASDAQ:NVDA", openDate, shares, buyPrice)
 			if err != nil {
 				t.Fatalf("Failed to create NVDA position for month %d: %v", month, err)
 			}
@@ -468,14 +468,14 @@ func createDeterministicMonthlyData(t *testing.T, db *database.DB) {
 		dividendAmount := 25.50 + float64(month)*2.25
 		dividendDate := monthDate.AddDate(0, 0, 25) // 25th of each month
 
-		_, err = dividendService.Create("AAPL", dividendDate, dividendAmount)
+		_, err = dividendService.Create("NASDAQ:AAPL", dividendDate, dividendAmount)
 		if err != nil {
 			t.Fatalf("Failed to create AAPL dividend for month %d: %v", month, err)
 		}
 
 		// Create TSLA dividends (smaller amount)
 		tslaDividend := 15.25 + float64(month)*1.75
-		_, err = dividendService.Create("TSLA", dividendDate, tslaDividend)
+		_, err = dividendService.Create("NASDAQ:TSLA", dividendDate, tslaDividend)
 		if err != nil {
 			t.Fatalf("Failed to create TSLA dividend for month %d: %v", month, err)
 		}

--- a/test/monthly_handlers_test.go
+++ b/test/monthly_handlers_test.go
@@ -408,7 +408,7 @@ func createDeterministicMonthlyData(t *testing.T, db *database.DB) {
 	dividendService := models.NewDividendService(db.DB)
 
 	// Create symbols
-	symbols := []string{"AAPL", "TSLA", "NVDA"}
+	symbols := []string{"NASDAQ:AAPL", "NASDAQ:TSLA", "NASDAQ:NVDA"}
 	for _, symbol := range symbols {
 		if _, err := symbolService.Create(symbol); err != nil {
 			t.Fatalf("Failed to create symbol %s: %v", symbol, err)

--- a/test/providers_service_test.go
+++ b/test/providers_service_test.go
@@ -77,10 +77,14 @@ func TestGetAPIKeyStatus_Polygon(t *testing.T) {
 
 			settingService := models.NewSettingService(db.DB)
 			if tt.providerType != "" {
-				settingService.SetValue("DATA_PROVIDER_TYPE", tt.providerType, "")
+				if err := settingService.SetValue("DATA_PROVIDER_TYPE", tt.providerType, ""); err != nil {
+					t.Fatalf("failed to set DATA_PROVIDER_TYPE: %v", err)
+				}
 			}
 			if tt.apiKey != "" {
-				settingService.SetValue("POLYGON_API_KEY", tt.apiKey, "")
+				if err := settingService.SetValue("POLYGON_API_KEY", tt.apiKey, ""); err != nil {
+					t.Fatalf("failed to set POLYGON_API_KEY: %v", err)
+				}
 			}
 
 			symbolService := models.NewSymbolService(db.DB)
@@ -172,16 +176,23 @@ func TestUpdateAllSymbolPrices_MissingAPIKey(t *testing.T) {
 
 	settingService := models.NewSettingService(db.DB)
 	settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
-	// No API key
 
+	// No API key
 	symbolService := models.NewSymbolService(db.DB)
+
 	// Create test symbols
-	symbolService.Create("AAPL")
-	symbolService.Create("GOOGL")
+	_, err := symbolService.Create("AAPL")
+	if err != nil {
+		t.Fatalf("failed to create symbol AAPL: %v", err)
+	}
+	_, err = symbolService.Create("GOOGL")
+	if err != nil {
+		t.Fatalf("failed to create symbol GOOGL: %v", err)
+	}
 
 	service := providers.NewService(symbolService, settingService)
 
-	err := service.UpdateAllSymbolPrices(ctx)
+	err = service.UpdateAllSymbolPrices(ctx)
 	if err == nil {
 		t.Fatal("Expected error without API key, got nil")
 	}

--- a/test/providers_service_test.go
+++ b/test/providers_service_test.go
@@ -108,8 +108,12 @@ func TestGetAPIKeyStatus_UnsupportedProvider(t *testing.T) {
 	db := setupProvidersTestDB(t)
 
 	settingService := models.NewSettingService(db.DB)
-	settingService.SetValue("DATA_PROVIDER_TYPE", "unknown_provider", "")
-	settingService.SetValue("POLYGON_API_KEY", "some_key", "")
+	if err := settingService.SetValue("DATA_PROVIDER_TYPE", "unknown_provider", ""); err != nil {
+		t.Fatalf("failed to set DATA_PROVIDER_TYPE: %v", err)
+	}
+	if err := settingService.SetValue("POLYGON_API_KEY", "some_key", ""); err != nil {
+		t.Fatalf("failed to set POLYGON_API_KEY: %v", err)
+	}
 
 	symbolService := models.NewSymbolService(db.DB)
 	service := providers.NewService(symbolService, settingService)

--- a/test/providers_service_test.go
+++ b/test/providers_service_test.go
@@ -1,33 +1,34 @@
 package test
 
 import (
-"context"
-"os"
-"stonks/internal/database"
-"stonks/internal/models"
-"stonks/internal/providers"
-"testing"
-"time"
+	"context"
+	"os"
+	"stonks/internal/database"
+	"stonks/internal/models"
+	"stonks/internal/providers"
+	"strings"
+	"testing"
+	"time"
 )
 
 // setupProvidersTestDB creates a temporary test database for provider tests
 func setupProvidersTestDB(t *testing.T) *database.DB {
 	testDBPath := "./data/providers_test.db"
-	
+
 	if err := os.Remove(testDBPath); err != nil && !os.IsNotExist(err) {
 		t.Logf("Note: Could not delete existing test database: %v", err)
 	}
-	
+
 	db, err := database.NewDB(testDBPath)
 	if err != nil {
 		t.Fatalf("Failed to create test database: %v", err)
 	}
-	
+
 	t.Cleanup(func() {
 		db.Close()
 		os.Remove(testDBPath)
 	})
-	
+
 	return db
 }
 
@@ -72,20 +73,20 @@ func TestGetAPIKeyStatus_Polygon(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-db := setupProvidersTestDB(t)
+			db := setupProvidersTestDB(t)
 
-settingService := models.NewSettingService(db.DB)
-if tt.providerType != "" {
-settingService.SetValue("DATA_PROVIDER_TYPE", tt.providerType, "")
-}
-if tt.apiKey != "" {
-settingService.SetValue("POLYGON_API_KEY", tt.apiKey, "")
-}
+			settingService := models.NewSettingService(db.DB)
+			if tt.providerType != "" {
+				settingService.SetValue("DATA_PROVIDER_TYPE", tt.providerType, "")
+			}
+			if tt.apiKey != "" {
+				settingService.SetValue("POLYGON_API_KEY", tt.apiKey, "")
+			}
 
-symbolService := models.NewSymbolService(db.DB)
-service := providers.NewService(symbolService, settingService)
+			symbolService := models.NewSymbolService(db.DB)
+			service := providers.NewService(symbolService, settingService)
 
-status := service.GetAPIKeyStatus()
+			status := service.GetAPIKeyStatus()
 
 			if status.Configured != tt.wantConfigured {
 				t.Errorf("Expected Configured=%v, got %v", tt.wantConfigured, status.Configured)
@@ -129,203 +130,191 @@ func TestUpdateSymbolPrice_MissingAPIKey(t *testing.T) {
 	settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
 	// Don't set POLYGON_API_KEY
 
-symbolService := models.NewSymbolService(db.DB)
-service := providers.NewService(symbolService, settingService)
+	symbolService := models.NewSymbolService(db.DB)
+	service := providers.NewService(symbolService, settingService)
 
-err := service.UpdateSymbolPrice(ctx, "AAPL")
-if err == nil {
-t.Fatal("Expected error when API key is missing, got nil")
-}
+	err := service.UpdateSymbolPrice(ctx, "AAPL")
+	if err == nil {
+		t.Fatal("Expected error when API key is missing, got nil")
+	}
 
-if !stringContains(err.Error(), "failed to get provider") {
-t.Errorf("Expected error about provider, got: %v", err)
-}
+	if !strings.Contains(err.Error(), "failed to get provider") {
+		t.Errorf("Expected error about provider, got: %v", err)
+	}
 }
 
 // TestUpdateSymbolPrice_UnsupportedProvider tests error with unsupported provider
 func TestUpdateSymbolPrice_UnsupportedProvider(t *testing.T) {
-ctx := context.Background()
-db := setupProvidersTestDB(t)
+	ctx := context.Background()
+	db := setupProvidersTestDB(t)
 
-settingService := models.NewSettingService(db.DB)
-settingService.SetValue("DATA_PROVIDER_TYPE", "unsupported", "")
-settingService.SetValue("POLYGON_API_KEY", "test_key", "")
+	settingService := models.NewSettingService(db.DB)
+	settingService.SetValue("DATA_PROVIDER_TYPE", "unsupported", "")
+	settingService.SetValue("POLYGON_API_KEY", "test_key", "")
 
-symbolService := models.NewSymbolService(db.DB)
-service := providers.NewService(symbolService, settingService)
+	symbolService := models.NewSymbolService(db.DB)
+	service := providers.NewService(symbolService, settingService)
 
-err := service.UpdateSymbolPrice(ctx, "AAPL")
-if err == nil {
-t.Fatal("Expected error when provider is unsupported, got nil")
-}
+	err := service.UpdateSymbolPrice(ctx, "AAPL")
+	if err == nil {
+		t.Fatal("Expected error when provider is unsupported, got nil")
+	}
 
-if !stringContains(err.Error(), "failed to get provider") {
-t.Errorf("Expected error about provider, got: %v", err)
-}
+	if !strings.Contains(err.Error(), "failed to get provider") {
+		t.Errorf("Expected error about provider, got: %v", err)
+	}
 }
 
 // TestUpdateAllSymbolPrices_MissingAPIKey tests bulk update without API key
 func TestUpdateAllSymbolPrices_MissingAPIKey(t *testing.T) {
-ctx := context.Background()
-db := setupProvidersTestDB(t)
+	ctx := context.Background()
+	db := setupProvidersTestDB(t)
 
-settingService := models.NewSettingService(db.DB)
-settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
-// No API key
+	settingService := models.NewSettingService(db.DB)
+	settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
+	// No API key
 
-symbolService := models.NewSymbolService(db.DB)
-// Create test symbols
-symbolService.Create("AAPL")
-symbolService.Create("GOOGL")
+	symbolService := models.NewSymbolService(db.DB)
+	// Create test symbols
+	symbolService.Create("AAPL")
+	symbolService.Create("GOOGL")
 
-service := providers.NewService(symbolService, settingService)
+	service := providers.NewService(symbolService, settingService)
 
-err := service.UpdateAllSymbolPrices(ctx)
-if err == nil {
-t.Fatal("Expected error without API key, got nil")
-}
+	err := service.UpdateAllSymbolPrices(ctx)
+	if err == nil {
+		t.Fatal("Expected error without API key, got nil")
+	}
 }
 
 // TestFetchSymbolDetails_MissingAPIKey tests fetch details without API key
 func TestFetchSymbolDetails_MissingAPIKey(t *testing.T) {
-ctx := context.Background()
-db := setupProvidersTestDB(t)
+	ctx := context.Background()
+	db := setupProvidersTestDB(t)
 
-settingService := models.NewSettingService(db.DB)
-settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
-// No API key - should fail
+	settingService := models.NewSettingService(db.DB)
+	settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
+	// No API key - should fail
 
-symbolService := models.NewSymbolService(db.DB)
-service := providers.NewService(symbolService, settingService)
+	symbolService := models.NewSymbolService(db.DB)
+	service := providers.NewService(symbolService, settingService)
 
-_, err := service.FetchSymbolDetails(ctx, "AAPL")
-if err == nil {
-t.Fatal("Expected error without API key, got nil")
-}
+	_, err := service.FetchSymbolDetails(ctx, "AAPL")
+	if err == nil {
+		t.Fatal("Expected error without API key, got nil")
+	}
 
-if !stringContains(err.Error(), "failed to get provider") {
-t.Errorf("Expected provider error, got: %v", err)
-}
+	if !strings.Contains(err.Error(), "failed to get provider") {
+		t.Errorf("Expected provider error, got: %v", err)
+	}
 }
 
 // TestFetchDividendHistory_MissingAPIKey tests dividend history without API key
 func TestFetchDividendHistory_MissingAPIKey(t *testing.T) {
-ctx := context.Background()
-db := setupProvidersTestDB(t)
+	ctx := context.Background()
+	db := setupProvidersTestDB(t)
 
-settingService := models.NewSettingService(db.DB)
-settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
-// No API key
+	settingService := models.NewSettingService(db.DB)
+	settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
+	// No API key
 
-symbolService := models.NewSymbolService(db.DB)
-service := providers.NewService(symbolService, settingService)
+	symbolService := models.NewSymbolService(db.DB)
+	service := providers.NewService(symbolService, settingService)
 
-_, err := service.FetchDividendHistory(ctx, "AAPL", 10)
-if err == nil {
-t.Fatal("Expected error without API key, got nil")
-}
+	_, err := service.FetchDividendHistory(ctx, "AAPL", 10)
+	if err == nil {
+		t.Fatal("Expected error without API key, got nil")
+	}
 
-if !stringContains(err.Error(), "failed to get provider") {
-t.Errorf("Expected provider error, got: %v", err)
-}
+	if !strings.Contains(err.Error(), "failed to get provider") {
+		t.Errorf("Expected provider error, got: %v", err)
+	}
 }
 
 // TestTestConnection_MissingAPIKey tests connection test without API key
 func TestTestConnection_MissingAPIKey(t *testing.T) {
-ctx := context.Background()
-db := setupProvidersTestDB(t)
+	ctx := context.Background()
+	db := setupProvidersTestDB(t)
 
-settingService := models.NewSettingService(db.DB)
-settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
-// No API key
+	settingService := models.NewSettingService(db.DB)
+	settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
+	// No API key
 
-symbolService := models.NewSymbolService(db.DB)
-service := providers.NewService(symbolService, settingService)
+	symbolService := models.NewSymbolService(db.DB)
+	service := providers.NewService(symbolService, settingService)
 
-err := service.TestConnection(ctx)
-if err == nil {
-t.Fatal("Expected error without API key, got nil")
-}
+	err := service.TestConnection(ctx)
+	if err == nil {
+		t.Fatal("Expected error without API key, got nil")
+	}
 }
 
 // TestGetRateLimitDelay tests rate limit delay configuration
 func TestGetRateLimitDelay(t *testing.T) {
-tests := []struct {
-name         string
-providerType string
-wantDelay    time.Duration
-}{
-{
-name:         "polygon provider",
-providerType: "polygon",
-wantDelay:    12 * time.Second,
-},
-{
-name:         "default provider",
-providerType: "",
-wantDelay:    12 * time.Second, // Defaults to polygon
-},
-{
-name:         "unknown provider",
-providerType: "unknown",
-wantDelay:    10 * time.Second,
-},
-}
+	tests := []struct {
+		name         string
+		providerType string
+		wantDelay    time.Duration
+	}{
+		{
+			name:         "polygon provider",
+			providerType: "polygon",
+			wantDelay:    12 * time.Second,
+		},
+		{
+			name:         "default provider",
+			providerType: "",
+			wantDelay:    12 * time.Second, // Defaults to polygon
+		},
+		{
+			name:         "unknown provider",
+			providerType: "unknown",
+			wantDelay:    10 * time.Second,
+		},
+	}
 
-for _, tt := range tests {
-t.Run(tt.name, func(t *testing.T) {
-db := setupProvidersTestDB(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := setupProvidersTestDB(t)
 
-settingService := models.NewSettingService(db.DB)
-if tt.providerType != "" {
-settingService.SetValue("DATA_PROVIDER_TYPE", tt.providerType, "")
-}
+			settingService := models.NewSettingService(db.DB)
+			if tt.providerType != "" {
+				settingService.SetValue("DATA_PROVIDER_TYPE", tt.providerType, "")
+			}
 
-symbolService := models.NewSymbolService(db.DB)
-service := providers.NewService(symbolService, settingService)
+			symbolService := models.NewSymbolService(db.DB)
+			service := providers.NewService(symbolService, settingService)
 
-delay := service.GetRateLimitDelay()
-if delay != tt.wantDelay {
-t.Errorf("Expected delay %v, got %v", tt.wantDelay, delay)
-}
-})
-}
+			delay := service.GetRateLimitDelay()
+			if delay != tt.wantDelay {
+				t.Errorf("Expected delay %v, got %v", tt.wantDelay, delay)
+			}
+		})
+	}
 }
 
 // TestDebugLogging tests that debug logging can be controlled
 func TestDebugLogging(t *testing.T) {
-db := setupProvidersTestDB(t)
+	db := setupProvidersTestDB(t)
 
-settingService := models.NewSettingService(db.DB)
-settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
-settingService.SetValue("POLYGON_API_KEY", "test_key_12345", "")
+	settingService := models.NewSettingService(db.DB)
+	settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
+	settingService.SetValue("POLYGON_API_KEY", "test_key_12345", "")
 
-symbolService := models.NewSymbolService(db.DB)
-service := providers.NewService(symbolService, settingService)
-
-// Test with DEBUG_PROVIDERS=1
-os.Setenv("DEBUG_PROVIDERS", "1")
-defer os.Unsetenv("DEBUG_PROVIDERS")
-
-// This test just verifies that the service doesn't panic when DEBUG_PROVIDERS is set
+	symbolService := models.NewSymbolService(db.DB)
+	// Test with DEBUG_PROVIDERS=1
+	os.Setenv("DEBUG_PROVIDERS", "1")
+	defer os.Unsetenv("DEBUG_PROVIDERS")
+	serviceDebug := providers.NewService(symbolService, settingService)
+	// This test just verifies that the service doesn't panic when DEBUG_PROVIDERS is set
 	// In a real scenario, we'd test actual provider behavior
-if service == nil {
-t.Fatal("Expected service, got nil")
-}
-
-// Test without DEBUG_PROVIDERS
-os.Unsetenv("DEBUG_PROVIDERS")
-if service == nil {
-t.Fatal("Expected service, got nil")
-}
-}
-
-// Helper function to check if a string contains a substring
-func stringContains(s, substr string) bool {
-for i := 0; i <= len(s)-len(substr); i++ {
-if s[i:i+len(substr)] == substr {
-return true
-}
-}
-return false
+	if serviceDebug == nil {
+		t.Fatal("Expected service with debug enabled, got nil")
+	}
+	// Test without DEBUG_PROVIDERS
+	os.Unsetenv("DEBUG_PROVIDERS")
+	service := providers.NewService(symbolService, settingService)
+	if service == nil {
+		t.Fatal("Expected service with debug disabled, got nil")
+	}
 }

--- a/test/providers_service_test.go
+++ b/test/providers_service_test.go
@@ -196,7 +196,7 @@ func TestUpdateAllSymbolPrices_MissingAPIKey(t *testing.T) {
 
 	service := providers.NewService(symbolService, settingService)
 
-	err = service.UpdateAllSymbolPrices(ctx)
+	_, err = service.UpdateAllSymbolPrices(ctx)
 	if err == nil {
 		t.Fatal("Expected error without API key, got nil")
 	}

--- a/test/providers_service_test.go
+++ b/test/providers_service_test.go
@@ -1,0 +1,331 @@
+package test
+
+import (
+"context"
+"os"
+"stonks/internal/database"
+"stonks/internal/models"
+"stonks/internal/providers"
+"testing"
+"time"
+)
+
+// setupProvidersTestDB creates a temporary test database for provider tests
+func setupProvidersTestDB(t *testing.T) *database.DB {
+	testDBPath := "./data/providers_test.db"
+	
+	if err := os.Remove(testDBPath); err != nil && !os.IsNotExist(err) {
+		t.Logf("Note: Could not delete existing test database: %v", err)
+	}
+	
+	db, err := database.NewDB(testDBPath)
+	if err != nil {
+		t.Fatalf("Failed to create test database: %v", err)
+	}
+	
+	t.Cleanup(func() {
+		db.Close()
+		os.Remove(testDBPath)
+	})
+	
+	return db
+}
+
+// TestGetAPIKeyStatus_Polygon tests API key status with Polygon provider
+func TestGetAPIKeyStatus_Polygon(t *testing.T) {
+	tests := []struct {
+		name           string
+		providerType   string
+		apiKey         string
+		wantConfigured bool
+		wantMasked     string
+	}{
+		{
+			name:           "configured with long key",
+			providerType:   "polygon",
+			apiKey:         "abcdefghijklmnop",
+			wantConfigured: true,
+			wantMasked:     "abc...nop",
+		},
+		{
+			name:           "configured with short key",
+			providerType:   "polygon",
+			apiKey:         "abc",
+			wantConfigured: true,
+			wantMasked:     "***",
+		},
+		{
+			name:           "not configured",
+			providerType:   "polygon",
+			apiKey:         "",
+			wantConfigured: false,
+			wantMasked:     "",
+		},
+		{
+			name:           "default to polygon when type not set",
+			providerType:   "",
+			apiKey:         "testkey123",
+			wantConfigured: true,
+			wantMasked:     "tes...123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+db := setupProvidersTestDB(t)
+
+settingService := models.NewSettingService(db.DB)
+if tt.providerType != "" {
+settingService.SetValue("DATA_PROVIDER_TYPE", tt.providerType, "")
+}
+if tt.apiKey != "" {
+settingService.SetValue("POLYGON_API_KEY", tt.apiKey, "")
+}
+
+symbolService := models.NewSymbolService(db.DB)
+service := providers.NewService(symbolService, settingService)
+
+status := service.GetAPIKeyStatus()
+
+			if status.Configured != tt.wantConfigured {
+				t.Errorf("Expected Configured=%v, got %v", tt.wantConfigured, status.Configured)
+			}
+
+			if status.Masked != tt.wantMasked {
+				t.Errorf("Expected Masked=%q, got %q", tt.wantMasked, status.Masked)
+			}
+		})
+	}
+}
+
+// TestGetAPIKeyStatus_UnsupportedProvider tests API key status with unsupported provider
+func TestGetAPIKeyStatus_UnsupportedProvider(t *testing.T) {
+	db := setupProvidersTestDB(t)
+
+	settingService := models.NewSettingService(db.DB)
+	settingService.SetValue("DATA_PROVIDER_TYPE", "unknown_provider", "")
+	settingService.SetValue("POLYGON_API_KEY", "some_key", "")
+
+	symbolService := models.NewSymbolService(db.DB)
+	service := providers.NewService(symbolService, settingService)
+
+	status := service.GetAPIKeyStatus()
+
+	if status.Configured {
+		t.Error("Expected Configured=false for unsupported provider")
+	}
+
+	if status.Masked != "" {
+		t.Errorf("Expected empty Masked for unsupported provider, got %q", status.Masked)
+	}
+}
+
+// TestUpdateSymbolPrice_MissingAPIKey tests error when API key is missing
+func TestUpdateSymbolPrice_MissingAPIKey(t *testing.T) {
+	ctx := context.Background()
+	db := setupProvidersTestDB(t)
+
+	settingService := models.NewSettingService(db.DB)
+	settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
+	// Don't set POLYGON_API_KEY
+
+symbolService := models.NewSymbolService(db.DB)
+service := providers.NewService(symbolService, settingService)
+
+err := service.UpdateSymbolPrice(ctx, "AAPL")
+if err == nil {
+t.Fatal("Expected error when API key is missing, got nil")
+}
+
+if !stringContains(err.Error(), "failed to get provider") {
+t.Errorf("Expected error about provider, got: %v", err)
+}
+}
+
+// TestUpdateSymbolPrice_UnsupportedProvider tests error with unsupported provider
+func TestUpdateSymbolPrice_UnsupportedProvider(t *testing.T) {
+ctx := context.Background()
+db := setupProvidersTestDB(t)
+
+settingService := models.NewSettingService(db.DB)
+settingService.SetValue("DATA_PROVIDER_TYPE", "unsupported", "")
+settingService.SetValue("POLYGON_API_KEY", "test_key", "")
+
+symbolService := models.NewSymbolService(db.DB)
+service := providers.NewService(symbolService, settingService)
+
+err := service.UpdateSymbolPrice(ctx, "AAPL")
+if err == nil {
+t.Fatal("Expected error when provider is unsupported, got nil")
+}
+
+if !stringContains(err.Error(), "failed to get provider") {
+t.Errorf("Expected error about provider, got: %v", err)
+}
+}
+
+// TestUpdateAllSymbolPrices_MissingAPIKey tests bulk update without API key
+func TestUpdateAllSymbolPrices_MissingAPIKey(t *testing.T) {
+ctx := context.Background()
+db := setupProvidersTestDB(t)
+
+settingService := models.NewSettingService(db.DB)
+settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
+// No API key
+
+symbolService := models.NewSymbolService(db.DB)
+// Create test symbols
+symbolService.Create("AAPL")
+symbolService.Create("GOOGL")
+
+service := providers.NewService(symbolService, settingService)
+
+err := service.UpdateAllSymbolPrices(ctx)
+if err == nil {
+t.Fatal("Expected error without API key, got nil")
+}
+}
+
+// TestFetchSymbolDetails_MissingAPIKey tests fetch details without API key
+func TestFetchSymbolDetails_MissingAPIKey(t *testing.T) {
+ctx := context.Background()
+db := setupProvidersTestDB(t)
+
+settingService := models.NewSettingService(db.DB)
+settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
+// No API key - should fail
+
+symbolService := models.NewSymbolService(db.DB)
+service := providers.NewService(symbolService, settingService)
+
+_, err := service.FetchSymbolDetails(ctx, "AAPL")
+if err == nil {
+t.Fatal("Expected error without API key, got nil")
+}
+
+if !stringContains(err.Error(), "failed to get provider") {
+t.Errorf("Expected provider error, got: %v", err)
+}
+}
+
+// TestFetchDividendHistory_MissingAPIKey tests dividend history without API key
+func TestFetchDividendHistory_MissingAPIKey(t *testing.T) {
+ctx := context.Background()
+db := setupProvidersTestDB(t)
+
+settingService := models.NewSettingService(db.DB)
+settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
+// No API key
+
+symbolService := models.NewSymbolService(db.DB)
+service := providers.NewService(symbolService, settingService)
+
+_, err := service.FetchDividendHistory(ctx, "AAPL", 10)
+if err == nil {
+t.Fatal("Expected error without API key, got nil")
+}
+
+if !stringContains(err.Error(), "failed to get provider") {
+t.Errorf("Expected provider error, got: %v", err)
+}
+}
+
+// TestTestConnection_MissingAPIKey tests connection test without API key
+func TestTestConnection_MissingAPIKey(t *testing.T) {
+ctx := context.Background()
+db := setupProvidersTestDB(t)
+
+settingService := models.NewSettingService(db.DB)
+settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
+// No API key
+
+symbolService := models.NewSymbolService(db.DB)
+service := providers.NewService(symbolService, settingService)
+
+err := service.TestConnection(ctx)
+if err == nil {
+t.Fatal("Expected error without API key, got nil")
+}
+}
+
+// TestGetRateLimitDelay tests rate limit delay configuration
+func TestGetRateLimitDelay(t *testing.T) {
+tests := []struct {
+name         string
+providerType string
+wantDelay    time.Duration
+}{
+{
+name:         "polygon provider",
+providerType: "polygon",
+wantDelay:    12 * time.Second,
+},
+{
+name:         "default provider",
+providerType: "",
+wantDelay:    12 * time.Second, // Defaults to polygon
+},
+{
+name:         "unknown provider",
+providerType: "unknown",
+wantDelay:    10 * time.Second,
+},
+}
+
+for _, tt := range tests {
+t.Run(tt.name, func(t *testing.T) {
+db := setupProvidersTestDB(t)
+
+settingService := models.NewSettingService(db.DB)
+if tt.providerType != "" {
+settingService.SetValue("DATA_PROVIDER_TYPE", tt.providerType, "")
+}
+
+symbolService := models.NewSymbolService(db.DB)
+service := providers.NewService(symbolService, settingService)
+
+delay := service.GetRateLimitDelay()
+if delay != tt.wantDelay {
+t.Errorf("Expected delay %v, got %v", tt.wantDelay, delay)
+}
+})
+}
+}
+
+// TestDebugLogging tests that debug logging can be controlled
+func TestDebugLogging(t *testing.T) {
+db := setupProvidersTestDB(t)
+
+settingService := models.NewSettingService(db.DB)
+settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
+settingService.SetValue("POLYGON_API_KEY", "test_key_12345", "")
+
+symbolService := models.NewSymbolService(db.DB)
+service := providers.NewService(symbolService, settingService)
+
+// Test with DEBUG_PROVIDERS=1
+os.Setenv("DEBUG_PROVIDERS", "1")
+defer os.Unsetenv("DEBUG_PROVIDERS")
+
+// This test just verifies that the service doesn't panic when DEBUG_PROVIDERS is set
+	// In a real scenario, we'd test actual provider behavior
+if service == nil {
+t.Fatal("Expected service, got nil")
+}
+
+// Test without DEBUG_PROVIDERS
+os.Unsetenv("DEBUG_PROVIDERS")
+if service == nil {
+t.Fatal("Expected service, got nil")
+}
+}
+
+// Helper function to check if a string contains a substring
+func stringContains(s, substr string) bool {
+for i := 0; i <= len(s)-len(substr); i++ {
+if s[i:i+len(substr)] == substr {
+return true
+}
+}
+return false
+}

--- a/test/providers_service_test.go
+++ b/test/providers_service_test.go
@@ -135,8 +135,10 @@ func TestUpdateSymbolPrice_MissingAPIKey(t *testing.T) {
 	db := setupProvidersTestDB(t)
 
 	settingService := models.NewSettingService(db.DB)
-	settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
-	// Don't set POLYGON_API_KEY
+	if err := settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", ""); err != nil {
+		t.Fatalf("failed to set DATA_PROVIDER_TYPE: %v", err)
+	}
+	// Intentionally don't set POLYGON_API_KEY to test missing key scenario
 
 	symbolService := models.NewSymbolService(db.DB)
 	service := providers.NewService(symbolService, settingService)
@@ -157,8 +159,12 @@ func TestUpdateSymbolPrice_UnsupportedProvider(t *testing.T) {
 	db := setupProvidersTestDB(t)
 
 	settingService := models.NewSettingService(db.DB)
-	settingService.SetValue("DATA_PROVIDER_TYPE", "unsupported", "")
-	settingService.SetValue("POLYGON_API_KEY", "test_key", "")
+	if err := settingService.SetValue("DATA_PROVIDER_TYPE", "unsupported", ""); err != nil {
+		t.Fatalf("failed to set DATA_PROVIDER_TYPE: %v", err)
+	}
+	if err := settingService.SetValue("POLYGON_API_KEY", "test_key", ""); err != nil {
+		t.Fatalf("failed to set POLYGON_API_KEY: %v", err)
+	}
 
 	symbolService := models.NewSymbolService(db.DB)
 	service := providers.NewService(symbolService, settingService)
@@ -179,7 +185,9 @@ func TestUpdateAllSymbolPrices_MissingAPIKey(t *testing.T) {
 	db := setupProvidersTestDB(t)
 
 	settingService := models.NewSettingService(db.DB)
-	settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
+	if err := settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", ""); err != nil {
+		t.Fatalf("failed to set DATA_PROVIDER_TYPE: %v", err)
+	}
 
 	// No API key
 	symbolService := models.NewSymbolService(db.DB)
@@ -208,7 +216,9 @@ func TestFetchSymbolDetails_MissingAPIKey(t *testing.T) {
 	db := setupProvidersTestDB(t)
 
 	settingService := models.NewSettingService(db.DB)
-	settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
+	if err := settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", ""); err != nil {
+		t.Fatalf("failed to set DATA_PROVIDER_TYPE: %v", err)
+	}
 	// No API key - should fail
 
 	symbolService := models.NewSymbolService(db.DB)
@@ -230,7 +240,9 @@ func TestFetchDividendHistory_MissingAPIKey(t *testing.T) {
 	db := setupProvidersTestDB(t)
 
 	settingService := models.NewSettingService(db.DB)
-	settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
+	if err := settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", ""); err != nil {
+		t.Fatalf("failed to set DATA_PROVIDER_TYPE: %v", err)
+	}
 	// No API key
 
 	symbolService := models.NewSymbolService(db.DB)
@@ -252,7 +264,9 @@ func TestTestConnection_MissingAPIKey(t *testing.T) {
 	db := setupProvidersTestDB(t)
 
 	settingService := models.NewSettingService(db.DB)
-	settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
+	if err := settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", ""); err != nil {
+		t.Fatalf("failed to set DATA_PROVIDER_TYPE: %v", err)
+	}
 	// No API key
 
 	symbolService := models.NewSymbolService(db.DB)
@@ -294,7 +308,9 @@ func TestGetRateLimitDelay(t *testing.T) {
 
 			settingService := models.NewSettingService(db.DB)
 			if tt.providerType != "" {
-				settingService.SetValue("DATA_PROVIDER_TYPE", tt.providerType, "")
+				if err := settingService.SetValue("DATA_PROVIDER_TYPE", tt.providerType, ""); err != nil {
+					t.Fatalf("failed to set DATA_PROVIDER_TYPE: %v", err)
+				}
 			}
 
 			symbolService := models.NewSymbolService(db.DB)
@@ -313,8 +329,12 @@ func TestDebugLogging(t *testing.T) {
 	db := setupProvidersTestDB(t)
 
 	settingService := models.NewSettingService(db.DB)
-	settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", "")
-	settingService.SetValue("POLYGON_API_KEY", "test_key_12345", "")
+	if err := settingService.SetValue("DATA_PROVIDER_TYPE", "polygon", ""); err != nil {
+		t.Fatalf("failed to set DATA_PROVIDER_TYPE: %v", err)
+	}
+	if err := settingService.SetValue("POLYGON_API_KEY", "test_key_12345", ""); err != nil {
+		t.Fatalf("failed to set POLYGON_API_KEY: %v", err)
+	}
 
 	symbolService := models.NewSymbolService(db.DB)
 	// Test with DEBUG_PROVIDERS=1

--- a/test/symbol_handlers_test.go
+++ b/test/symbol_handlers_test.go
@@ -23,7 +23,7 @@ func TestSymbolDataStructure(t *testing.T) {
 	createDeterministicSymbolData(t, testDB)
 
 	// Build symbol data (simulating the handler)
-	symbolData := buildTestSymbolData(t, testDB, "AAPL")
+	symbolData := buildTestSymbolData(t, testDB, "NASDAQ:AAPL")
 
 	// Test JSON serialization/deserialization
 	jsonData, err := json.Marshal(symbolData)
@@ -38,8 +38,8 @@ func TestSymbolDataStructure(t *testing.T) {
 
 	// Validate basic symbol information
 	t.Run("BasicSymbolInfo", func(t *testing.T) {
-		if unmarshalled.Symbol != "AAPL" {
-			t.Errorf("Expected symbol AAPL, got %s", unmarshalled.Symbol)
+		if unmarshalled.Symbol != "NASDAQ:AAPL" {
+			t.Errorf("Expected symbol NASDAQ:AAPL, got %s", unmarshalled.Symbol)
 		}
 		if unmarshalled.CompanyName == "" {
 			t.Error("CompanyName should not be empty")
@@ -83,8 +83,8 @@ func TestSymbolDataStructure(t *testing.T) {
 
 		// Validate dividends list structure
 		for i, dividend := range unmarshalled.DividendsList {
-			if dividend.Symbol != "AAPL" {
-				t.Errorf("Dividend %d should be for AAPL, got %s", i, dividend.Symbol)
+			if dividend.Symbol != "NASDAQ:AAPL" {
+				t.Errorf("Dividend %d should be for NASDAQ:AAPL, got %s", i, dividend.Symbol)
 			}
 			if dividend.Amount <= 0 {
 				t.Errorf("Dividend %d amount should be positive, got %f", i, dividend.Amount)
@@ -99,8 +99,8 @@ func TestSymbolDataStructure(t *testing.T) {
 		}
 
 		for i, option := range unmarshalled.OptionsList {
-			if option.Symbol != "AAPL" {
-				t.Errorf("Option %d should be for AAPL, got %s", i, option.Symbol)
+			if option.Symbol != "NASDAQ:AAPL" {
+				t.Errorf("Option %d should be for NASDAQ:AAPL, got %s", i, option.Symbol)
 			}
 			if option.Type != "Put" && option.Type != "Call" {
 				t.Errorf("Option %d should be Put or Call, got %s", i, option.Type)
@@ -153,8 +153,8 @@ func TestSymbolDataStructure(t *testing.T) {
 		}
 
 		for i, position := range unmarshalled.LongPositionsList {
-			if position.Symbol != "AAPL" {
-				t.Errorf("Position %d should be for AAPL, got %s", i, position.Symbol)
+			if position.Symbol != "NASDAQ:AAPL" {
+				t.Errorf("Position %d should be for NASDAQ:AAPL, got %s", i, position.Symbol)
 			}
 			if position.Shares <= 0 {
 				t.Errorf("Position %d shares should be positive, got %d", i, position.Shares)
@@ -271,8 +271,8 @@ func TestSymbolHandlerEndpoint(t *testing.T) {
 	// Create test server with symbol endpoint
 	server := createSymbolTestServer(testDB)
 
-	// Test the AAPL symbol endpoint
-	req, err := http.NewRequest("GET", "/symbol/AAPL", nil)
+	// Test the canonical AAPL symbol endpoint
+	req, err := http.NewRequest("GET", "/symbol/NASDAQ:AAPL", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -310,7 +310,7 @@ func TestMultipleSymbolsMonthlyData(t *testing.T) {
 	testDB := setupTestDB(t)
 	createDeterministicSymbolData(t, testDB)
 
-	symbols := []string{"AAPL", "TSLA", "NVDA"}
+	symbols := []string{"NASDAQ:AAPL", "NASDAQ:TSLA", "NASDAQ:NVDA"}
 
 	for _, symbol := range symbols {
 		t.Run(symbol, func(t *testing.T) {
@@ -354,7 +354,7 @@ func createDeterministicSymbolData(t *testing.T, db *database.DB) {
 	dividendService := models.NewDividendService(db.DB)
 
 	// Create symbols with detailed information
-	symbols := []string{"AAPL", "TSLA", "NVDA"}
+	symbols := []string{"NASDAQ:AAPL", "NASDAQ:TSLA", "NASDAQ:NVDA"}
 	prices := []float64{150.0, 200.0, 400.0}
 	dividends := []float64{0.75, 0.00, 0.25}
 

--- a/test/treasury_handlers_test.go
+++ b/test/treasury_handlers_test.go
@@ -394,7 +394,7 @@ func createDeterministicTreasuryData(t *testing.T, db *database.DB) {
 	symbolService := models.NewSymbolService(db.DB)
 
 	// Create some symbols for the treasuries data
-	symbols := []string{"AAPL", "TSLA", "NVDA"}
+	symbols := []string{"NASDAQ:AAPL", "NASDAQ:TSLA", "NASDAQ:NVDA"}
 	for _, symbol := range symbols {
 		if _, err := symbolService.Create(symbol); err != nil {
 			t.Fatalf("Failed to create symbol %s: %v", symbol, err)


### PR DESCRIPTION
TITLE
feat: add pluggable market data providers and symbol market qualification

OVERVIEW
Introduces a provider abstraction layer supporting Polygon.io, Google Finance, and Yahoo Finance (yfinance) for market data, with per-database configuration and validation.
Updates the web UI and settings flows to configure the active provider, manage related settings atomically, and surface provider-specific capabilities (API keys, exchanges, dividend support).
Moves market data routes and handlers from a Polygon-specific namespace to a generic provider API, including price updates, symbol info, connection tests, and dividend fetches.
Normalizes symbols to canonical MARKET:TICKER keys, adds markets parsing/qualification, and provides tooling to migrate legacy bare tickers in bulk along with dependent records.
Extends metrics and tests to be more deterministic and aligned with the new symbol format, and augments documentation (README, CLAUDE.md, Copilot instructions, model schema) to describe the provider system and market-aware symbols.